### PR TITLE
parser: support interchangable field and values in operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,14 @@ When evaluated against:
 - `map[string]any{"domain": "example.com"}` → returns **true**
 - `map[string]any{"domain": "qpoint.io"}` → returns **false**
 
-In this document, `domain` is referred to as the **field** and `/example\.com$/` as the **value**.
+In this document, `domain` is referred to as a **field** and `/example\.com$/` as a **value**.
+
+RuleKit supports a flexible syntax where fields and values may appear on either side of an operator:
+
+- `field operator value` (e.g., `domain == "example.com"`)
+- `value operator field` (e.g., `"example.com" == domain`)
+- `value operator value` (e.g., `123 == 123`)
+- `field operator field` (e.g., `src.port == dst.port`)
 
 A field on its own (without an operator) will check if the field contains a non-zero value. For example: `hash && version > 1` will check if the hash field is non-zero and the version is greater than 1.
 

--- a/rule.go
+++ b/rule.go
@@ -14,16 +14,23 @@ package rulekit
 			map[string]any{"domain": "example.com"} -> true
 			map[string]any{"domain": "qpoint.io"}   -> false
 
-	Operations always follow the syntax FIELD OPERATOR VALUE.
-		In the example expression:
-			FIELD:     domain
-			OPERATOR:  matches
-			VALUE:     /example\.com$/
+		In this example,
+			domain				is a FIELD,
+			matches				is the OPERATOR,
+			/example\.com$/		is the VALUE.
 
-	Additionally, a FIELD on its own without an operator will check if the field contains a non-zero value.
+	A FIELD or VALUE may appear on either side of an operator.
+		For example, all of the following expressions are valid:
+			- port == 8080
+			- 8080 == port
+			- src.port == dst.port
+			- 500 > 2
+
+	A FIELD or VALUE on its own without an operator will check if the field contains a non-zero value.
+		For example: `bool_field && string_field`
 
 	Supported operators:
-		== (eq), != (ne), > (gt), >= (ge), < (lt), <= (le), contains, matches
+		== (eq), != (ne), > (gt), >= (ge), < (lt), <= (le), contains, matches, in
 		or (||), and (&&), not (!)
 		() parentheses for grouping
 

--- a/rule_test.go
+++ b/rule_test.go
@@ -648,69 +648,70 @@ func (w *testWriter) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-func TestOptionalNegate(t *testing.T) {
-	{
-		f, err := Parse("field matches /pattern/")
-		require.NoError(t, err)
-		require.Equal(t, "field =~ /pattern/", f.String())
+// NOTE: This is no longer supported due to changes made in https://github.com/qpoint-io/rulekit/pull/8
+// func TestOptionalNegate(t *testing.T) {
+// 	{
+// 		f, err := Parse("field matches /pattern/")
+// 		require.NoError(t, err)
+// 		require.Equal(t, "field =~ /pattern/", f.String())
 
-		assertEval(t, f, map[string]any{"field": "pattern"}, true)
-		assertEval(t, f, map[string]any{"field": "other"}, false)
+// 		assertEval(t, f, map[string]any{"field": "pattern"}, true)
+// 		assertEval(t, f, map[string]any{"field": "other"}, false)
 
-		r, ok := f.(*rule)
-		require.True(t, ok)
-		_, ok = r.Rule.(*nodeMatch)
-		require.True(t, ok)
-	}
+// 		r, ok := f.(*rule)
+// 		require.True(t, ok)
+// 		_, ok = r.Rule.(*nodeMatch)
+// 		require.True(t, ok)
+// 	}
 
-	{
-		f, err := Parse("field not matches /pattern/")
-		require.NoError(t, err)
-		require.Equal(t, "field not =~ /pattern/", f.String())
+// 	{
+// 		f, err := Parse("field not matches /pattern/")
+// 		require.NoError(t, err)
+// 		require.Equal(t, "field not =~ /pattern/", f.String())
 
-		assertEval(t, f, map[string]any{"field": "pattern"}, false)
-		assertEval(t, f, map[string]any{"field": "other"}, true)
+// 		assertEval(t, f, map[string]any{"field": "pattern"}, false)
+// 		assertEval(t, f, map[string]any{"field": "other"}, true)
 
-		r, ok := f.(*rule)
-		require.True(t, ok)
-		n, ok := r.Rule.(*nodeNot)
-		require.True(t, ok)
-		_, ok = n.right.(*nodeMatch)
-		require.True(t, ok)
-	}
+// 		r, ok := f.(*rule)
+// 		require.True(t, ok)
+// 		n, ok := r.Rule.(*nodeNot)
+// 		require.True(t, ok)
+// 		_, ok = n.right.(*nodeMatch)
+// 		require.True(t, ok)
+// 	}
 
-	{
-		f, err := Parse(`field !contains "str"`)
-		require.NoError(t, err)
-		require.Equal(t, `field not contains "str"`, f.String())
+// 	{
+// 		f, err := Parse(`field !contains "str"`)
+// 		require.NoError(t, err)
+// 		require.Equal(t, `field not contains "str"`, f.String())
 
-		assertEval(t, f, map[string]any{"field": "string"}, false)
-		assertEval(t, f, map[string]any{"field": "other"}, true)
+// 		assertEval(t, f, map[string]any{"field": "string"}, false)
+// 		assertEval(t, f, map[string]any{"field": "other"}, true)
 
-		r, ok := f.(*rule)
-		require.True(t, ok)
-		n, ok := r.Rule.(*nodeNot)
-		require.True(t, ok)
-		_, ok = n.right.(*nodeCompare)
-		require.True(t, ok)
-	}
+// 		r, ok := f.(*rule)
+// 		require.True(t, ok)
+// 		n, ok := r.Rule.(*nodeNot)
+// 		require.True(t, ok)
+// 		_, ok = n.right.(*nodeCompare)
+// 		require.True(t, ok)
+// 	}
 
-	{
-		f := MustParse(`field not in [1.1.1.1, 192.168.0.0/16]`)
-		require.Equal(t, `field not in [1.1.1.1, 192.168.0.0/16]`, f.String())
+// 	{
+// 		f := MustParse(`field not in [1.1.1.1, 192.168.0.0/16]`)
+// 		require.Equal(t, `field not in [1.1.1.1, 192.168.0.0/16]`, f.String())
 
-		for ip, want := range map[string]bool{
-			"1.1.1.1":     false,
-			"192.168.0.0": false,
-			"192.168.0.1": false,
-			"192.0.1.1":   true,
-			"1.1.1.2":     true,
-		} {
-			v := net.ParseIP(ip)
-			assertEval(t, f, KV{"field": v}, want)
-		}
-	}
-}
+// 		for ip, want := range map[string]bool{
+// 			"1.1.1.1":     false,
+// 			"192.168.0.0": false,
+// 			"192.168.0.1": false,
+// 			"192.0.1.1":   true,
+// 			"1.1.1.2":     true,
+// 		} {
+// 			v := net.ParseIP(ip)
+// 			assertEval(t, f, KV{"field": v}, want)
+// 		}
+// 	}
+// }
 
 func TestArray(t *testing.T) {
 	assertParseError(t, `field == [1,]`)

--- a/rule_test.go
+++ b/rule_test.go
@@ -694,6 +694,22 @@ func TestOptionalNegate(t *testing.T) {
 		_, ok = n.right.(*nodeCompare)
 		require.True(t, ok)
 	}
+
+	{
+		f := MustParse(`field not in [1.1.1.1, 192.168.0.0/16]`)
+		require.Equal(t, `field not in [1.1.1.1, 192.168.0.0/16]`, f.String())
+
+		for ip, want := range map[string]bool{
+			"1.1.1.1":     false,
+			"192.168.0.0": false,
+			"192.168.0.1": false,
+			"192.0.1.1":   true,
+			"1.1.1.2":     true,
+		} {
+			v := net.ParseIP(ip)
+			assertEval(t, f, KV{"field": v}, want)
+		}
+	}
 }
 
 func TestArray(t *testing.T) {
@@ -730,6 +746,22 @@ func TestArray(t *testing.T) {
 	assertParseEval(t, `f == "string"`, KV{"f": []any{1, "str", 3}}, false)       // false (no element equals "string")
 	assertParseEval(t, `f != "string"`, KV{"f": []any{1, "str", 3}}, true)        // true  (no element equals "string")
 	assertParseEval(t, `f contains "string"`, KV{"f": []any{1, "str", 3}}, false) // false (array doesn't contain "string")
+
+	{
+		f := MustParse(`arr contains val`)
+
+		assertEval(t, f, KV{
+			"arr": []any{1, "str", 3},
+			"val": "str",
+		}, true)
+		assertEval(t, f, KV{
+			"arr": []any{1, "str", 3},
+			"val": 50,
+		}, false)
+	}
+
+	assertParseEval(t, `[1,2,3] contains 2`, nil, true)
+	assertParseEval(t, `[1,2,3] contains "str"`, nil, false)
 }
 
 func TestIn(t *testing.T) {
@@ -743,24 +775,13 @@ func TestIn(t *testing.T) {
 		assertEval(t, f, KV{"field": 123}, false)
 	}
 
-	{
-		f := MustParse(`field not in [1.1.1.1, 192.168.0.0/16]`)
-		require.Equal(t, `field not in [1.1.1.1, 192.168.0.0/16]`, f.String())
-
-		for ip, want := range map[string]bool{
-			"1.1.1.1":     false,
-			"192.168.0.0": false,
-			"192.168.0.1": false,
-			"192.0.1.1":   true,
-			"1.1.1.2":     true,
-		} {
-			v := net.ParseIP(ip)
-			assertEval(t, f, KV{"field": v}, want)
-		}
-	}
+	assertParseEval(t, `5 in [1,2,3]`, nil, false)
+	assertParseEval(t, `1.2.3.4 in [1.0.0.0/8, 8.8.8.8]`, nil, true)
+	assertParseEval(t, `192.168.0.1 in [1.0.0.0/8, 8.8.8.8]`, nil, false)
 }
 
 func assertParseEval(t *testing.T, rule string, input KV, pass bool) {
+	t.Helper()
 	r := MustParse(rule)
 	assertEval(t, r, input, pass)
 }
@@ -812,4 +833,78 @@ func TestOperationValidity(t *testing.T) {
 
 	_ = MustParse(`f >= 1`)
 	_ = MustParse(`f < 1.5`)
+}
+
+func TestSpecialBooleanFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		rule     string
+		input    map[string]any
+		expected bool
+	}{
+		{
+			name:     "standalone true",
+			rule:     "true",
+			input:    map[string]any{},
+			expected: true,
+		},
+		{
+			name:     "standalone false",
+			rule:     "false",
+			input:    map[string]any{},
+			expected: false,
+		},
+		{
+			name:     "true equals true",
+			rule:     "true == true",
+			input:    map[string]any{},
+			expected: true,
+		},
+		{
+			name:     "false equals false",
+			rule:     "false == false",
+			input:    map[string]any{},
+			expected: true,
+		},
+		{
+			name:     "true not equals false",
+			rule:     "true != false",
+			input:    map[string]any{},
+			expected: true,
+		},
+		{
+			name:     "field equals true",
+			rule:     "field == true",
+			input:    map[string]any{"field": true},
+			expected: true,
+		},
+		{
+			name:     "field not equals true",
+			rule:     "field != true",
+			input:    map[string]any{"field": false},
+			expected: true,
+		},
+		{
+			name:     "case insensitive TRUE",
+			rule:     "TRUE == true",
+			input:    map[string]any{},
+			expected: true,
+		},
+		{
+			name:     "case insensitive FALSE",
+			rule:     "FALSE == false",
+			input:    map[string]any{},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := MustParse(tt.rule)
+			result := rule.Eval(tt.input)
+			if result.Pass != tt.expected {
+				t.Errorf("Expected %v, got %v for rule: %s", tt.expected, result.Pass, tt.rule)
+			}
+		})
+	}
 }

--- a/values.go
+++ b/values.go
@@ -68,6 +68,8 @@ func isZero(val any) bool {
 		return len(v) == 0
 	case *net.IPNet:
 		return v == nil || v.IP == nil
+	case []any:
+		return len(v) == 0
 	}
 	return false
 }


### PR DESCRIPTION
Remove the strict `FIELD OP VALUE` pattern and allow fields/values to appear on either side of an operation.

- Traditional: `field operator value` (e.g., `domain == "example.com"`)
- Reversed: `value operator field` (e.g., `"example.com" == domain`)
- Literal comparison: `value operator value` (e.g., `123 == 123`)
- Field comparison: `field operator field` (e.g., `src.port == dst.port`)

---

WIP - this made `op_NOT` ambiguous and broke optional negation.

The parser is now conflicted on how to parse e.g. `port not eq 80`. Is it `port (not eq) 80` or `port (not eq 80)`