### PR TITLE
replace MissingFields with an error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,60 @@
+package rulekit
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/qpoint-io/rulekit/set"
+)
+
+type ErrMissingFields struct {
+	Fields set.Set[string]
+}
+
+func (e ErrMissingFields) Error() string {
+	return fmt.Sprintf("missing fields: %v", e.Fields)
+}
+
+func coalesceErrs(errs ...error) error {
+	var (
+		multi = &multierror.Error{
+			ErrorFormat: func(errs []error) string {
+				switch len(errs) {
+				case 0:
+					return ""
+				case 1:
+					return errs[0].Error()
+				default:
+					return multierror.ListFormatFunc(errs)
+				}
+			},
+		}
+		// combine all ErrMissingFields errors
+		mf = set.NewSet[string]()
+	)
+
+	for _, err := range errs {
+		if e, ok := err.(*ErrMissingFields); ok {
+			mf.Merge(e.Fields)
+			continue
+		}
+
+		multi = multierror.Append(multi, err)
+	}
+
+	if mf.Len() > 0 {
+		multi = multierror.Append(multi, &ErrMissingFields{Fields: mf})
+	}
+
+	switch len(multi.Errors) {
+	case 0:
+		return nil
+	case 1:
+		return multi.Errors[0]
+	default:
+		return multi
+	}
+}
+
+var ErrInvalidOperation = errors.New("invalid operation")

--- a/example/rulecli/main.go
+++ b/example/rulecli/main.go
@@ -521,9 +521,9 @@ func (m *model) evaluateRule() {
 	sb.WriteString(fmt.Sprintf("%s\n\n", rule))
 
 	// Show missing fields if any
-	if len(result.MissingFields) > 0 {
-		sb.WriteString(labelStyle.Render("Missing Fields: "))
-		sb.WriteString(fmt.Sprintf("%v\n\n", result.MissingFields))
+	if result.Error != nil {
+		sb.WriteString(labelStyle.Render("Error: "))
+		sb.WriteString(fmt.Sprintf("%v\n\n", result.Error))
 	}
 
 	// Show test data last

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,14 @@ module github.com/qpoint-io/rulekit
 go 1.23.4
 
 require (
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/exp v0.0.0-20250228200357-dead58393ab7
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/rule.go
+++ b/rule.go
@@ -95,8 +95,6 @@ import (
 	"fmt"
 	"strings"
 	"unicode/utf8"
-
-	"github.com/qpoint-io/rulekit/set"
 )
 
 // Parse parses a rule expression and returns a Rule.
@@ -159,23 +157,23 @@ func (r *rule) String() string {
 
 type Result struct {
 	Pass          bool
-	MissingFields set.Set[string]
 	EvaluatedRule Rule
+	Error         error
+}
+
+// Ok returns true if the rule was able to evaluate.
+func (r Result) Ok() bool {
+	return r.Error == nil
 }
 
 // Pass returns true if the rule passes and all required fields are present.
 func (r Result) PassStrict() bool {
-	return r.Pass && r.Strict()
+	return r.Pass && r.Ok()
 }
 
 // FailStrict returns true if the rule fails and all required fields are present.
 func (r Result) FailStrict() bool {
-	return !r.Pass && r.Strict()
-}
-
-// Strict returns true if the rule fails and all required fields are present.
-func (r Result) Strict() bool {
-	return len(r.MissingFields) == 0
+	return !r.Pass && r.Ok()
 }
 
 type ParseError struct {

--- a/set/set.go
+++ b/set/set.go
@@ -42,6 +42,10 @@ func (s Set[T]) Merge(other Set[T]) {
 	s.Add(other.Items()...)
 }
 
+func (s Set[T]) Len() int {
+	return len(s)
+}
+
 func Union[T comparable](sets ...Set[T]) Set[T] {
 	var union Set[T]
 	for _, set := range sets {

--- a/values.go
+++ b/values.go
@@ -35,11 +35,17 @@ func (l LiteralValue[T]) String() string {
 	return l.raw
 }
 
-func valuerToMissingFields(rv Valuer) set.Set[string] {
-	if v, ok := rv.(FieldValue); ok {
-		return set.NewSet(string(v))
+func valuersToMissingFields(rv ...Valuer) *ErrMissingFields {
+	fields := set.NewSet[string]()
+	for _, v := range rv {
+		if v, ok := v.(FieldValue); ok {
+			fields.Add(string(v))
+		}
 	}
-	return nil
+	if fields.Len() == 0 {
+		return nil
+	}
+	return &ErrMissingFields{Fields: fields}
 }
 
 func isZero(val any) bool {


### PR DESCRIPTION
This replaces `MissingFields set.Set[string]` on `Result` with an more general `Error error` field using a custom `*MissingFields` error type paving the way for additional types of errors.