### PR TITLE
Eval: use a Ctx struct as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ func main() {
     }
     
     // Define input data
-    inputData := map[string]any{
+    inputData := rulekit.KV{
         "domain": "example.com",
         "port": 8080,
     }
     
-    // Evaluate the rule
-    result := r.Eval(inputData)
+    // Evaluate the rule using Ctx
+    result := r.Eval(&rulekit.Ctx{KV: inputData})
     
     if result.PassStrict() {
         fmt.Println("Rule matched!")
@@ -85,6 +85,21 @@ The Result also provides additional helper methods:
 - `Pass()`: Returns true if the rule returns true/a non-zero value with no errors
 - `Fail()`: Returns true if the rule returns false/a zero value with no errors
 - `Ok()`: Returns true if the rule executed with no error
+
+## Context
+
+Rules are evaluated with a context input containing field values. `rulekit.KV` is an alias for `map[string]any`.
+
+```go
+ctx := &rulekit.Ctx{
+    KV: rulekit.KV{
+        "domain": "example.com",
+        "port": 8080,
+    },
+}
+
+result := rule.Eval(ctx)
+```
 
 ## Supported Operators
 

--- a/example/rulecli/main.go
+++ b/example/rulecli/main.go
@@ -494,7 +494,7 @@ func (m *model) evaluateRule() {
 	}
 
 	// Evaluate rule
-	result := rule.Eval(data)
+	result := rule.Eval(&rulekit.Ctx{KV: data})
 
 	// Format the result
 	var sb strings.Builder

--- a/nodes.go
+++ b/nodes.go
@@ -11,14 +11,14 @@ type nodeAnd struct {
 	right Rule
 }
 
-func (n *nodeAnd) Eval(p map[string]any) Result {
+func (n *nodeAnd) Eval(ctx *Ctx) Result {
 	// if either node fails, return only that node
-	rleft := n.left.Eval(p)
+	rleft := n.left.Eval(ctx)
 	if rleft.Fail() {
 		return rleft
 	}
 
-	rright := n.right.Eval(p)
+	rright := n.right.Eval(ctx)
 	if rright.Fail() {
 		return rright
 	}
@@ -57,14 +57,14 @@ type nodeOr struct {
 	right Rule
 }
 
-func (n *nodeOr) Eval(p map[string]any) Result {
+func (n *nodeOr) Eval(ctx *Ctx) Result {
 	// if either node passes, return only that node
-	rleft := n.left.Eval(p)
+	rleft := n.left.Eval(ctx)
 	if rleft.Pass() {
 		return rleft
 	}
 
-	rright := n.right.Eval(p)
+	rright := n.right.Eval(ctx)
 	if rright.Pass() {
 		return rright
 	}
@@ -102,12 +102,12 @@ type nodeNot struct {
 	right Rule
 }
 
-func (n *nodeNot) Eval(p map[string]any) Result {
+func (n *nodeNot) Eval(ctx *Ctx) Result {
 	if n.right == nil {
 		return Result{EvaluatedRule: n}
 	}
 
-	r := n.right.Eval(p)
+	r := n.right.Eval(ctx)
 
 	res := Result{
 		EvaluatedRule: n,
@@ -149,8 +149,8 @@ type nodeNotZero struct {
 	rv Valuer
 }
 
-func (n *nodeNotZero) Eval(p map[string]any) Result {
-	val, ok := n.rv.Value(p)
+func (n *nodeNotZero) Eval(ctx *Ctx) Result {
+	val, ok := n.rv.Value(ctx)
 	if !ok {
 		return Result{
 			Error:         valuersToMissingFields(n.rv),
@@ -174,9 +174,9 @@ type nodeMatch struct {
 	rv Valuer
 }
 
-func (n *nodeMatch) Eval(p map[string]any) Result {
-	lv, lvOk := n.lv.Value(p)
-	rv, rvOk := n.rv.Value(p)
+func (n *nodeMatch) Eval(ctx *Ctx) Result {
+	lv, lvOk := n.lv.Value(ctx)
+	rv, rvOk := n.rv.Value(ctx)
 	if !lvOk || !rvOk {
 		return Result{
 			Error:         valuersToMissingFields(n.lv, n.rv),
@@ -224,9 +224,9 @@ type nodeCompare struct {
 	rv Valuer
 }
 
-func (n *nodeCompare) Eval(m map[string]any) Result {
-	lv, lvOk := n.lv.Value(m)
-	rv, rvOk := n.rv.Value(m)
+func (n *nodeCompare) Eval(ctx *Ctx) Result {
+	lv, lvOk := n.lv.Value(ctx)
+	rv, rvOk := n.rv.Value(ctx)
 	if !lvOk || !rvOk {
 		r := Result{
 			Error:         valuersToMissingFields(n.lv, n.rv),
@@ -252,9 +252,9 @@ type nodeIn struct {
 	rv Valuer
 }
 
-func (n *nodeIn) Eval(p map[string]any) Result {
-	lv, lvOk := n.lv.Value(p)
-	rv, rvOk := n.rv.Value(p)
+func (n *nodeIn) Eval(ctx *Ctx) Result {
+	lv, lvOk := n.lv.Value(ctx)
+	rv, rvOk := n.rv.Value(ctx)
 	if !lvOk || !rvOk {
 		return Result{
 			Error:         valuersToMissingFields(n.lv, n.rv),

--- a/rule.go
+++ b/rule.go
@@ -128,9 +128,17 @@ func MustParse(str string) Rule {
 
 type KV = map[string]any
 
+type Ctx struct {
+	KV KV
+}
+
+func (c *Ctx) Eval(r Rule) Result {
+	return r.Eval(c)
+}
+
 type Rule interface {
-	// Checks whether the input fields match the rule.
-	Eval(KV) Result
+	// Evaluates the rule with the context
+	Eval(*Ctx) Result
 	// String representation of the rule
 	String() string
 }
@@ -140,8 +148,8 @@ type rule struct {
 }
 
 // Eval overrides the rule's Eval() method to wrap the returned EvalutedRule so we can override the String() method.
-func (r *rule) Eval(fv KV) Result {
-	res := r.Rule.Eval(fv)
+func (r *rule) Eval(ctx *Ctx) Result {
+	res := r.Rule.Eval(ctx)
 	res.EvaluatedRule = &rule{Rule: res.EvaluatedRule}
 	return res
 }

--- a/string_cast_test.go
+++ b/string_cast_test.go
@@ -59,7 +59,7 @@ func TestStringAutomaticCasting(t *testing.T) {
 			r, err := Parse(tc.ruleExpr)
 			require.NoError(t, err)
 
-			result := r.Eval(tc.inputData)
+			result := r.Eval(&Ctx{KV: tc.inputData})
 			assert.Equal(t, tc.expected, result.Pass(), "rule: %s", tc.ruleExpr)
 		})
 	}

--- a/values.go
+++ b/values.go
@@ -8,14 +8,14 @@ import (
 )
 
 type Valuer interface {
-	Value(map[string]any) (any, bool)
+	Value(*Ctx) (any, bool)
 	String() string
 }
 
 type FieldValue string
 
-func (f FieldValue) Value(m map[string]any) (any, bool) {
-	return mapPath(m, string(f))
+func (f FieldValue) Value(ctx *Ctx) (any, bool) {
+	return mapPath(ctx.KV, string(f))
 }
 
 func (f FieldValue) String() string {
@@ -27,7 +27,7 @@ type LiteralValue[T any] struct {
 	value T
 }
 
-func (l *LiteralValue[T]) Value(m map[string]any) (any, bool) {
+func (l *LiteralValue[T]) Value(ctx *Ctx) (any, bool) {
 	return l.value, true
 }
 


### PR DESCRIPTION
Wrap `Eval`'s KV input with a `Ctx` struct.