### PR TITLE
add support for functions

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -58,3 +58,13 @@ func coalesceErrs(errs ...error) error {
 }
 
 var ErrInvalidOperation = errors.New("invalid operation")
+
+type ErrInvalidFunctionArg struct {
+	Index    int
+	Expected string
+	Got      string
+}
+
+func (e *ErrInvalidFunctionArg) Error() string {
+	return fmt.Sprintf("arg %d: expected %s, got %s", e.Index, e.Expected, e.Got)
+}

--- a/functions.go
+++ b/functions.go
@@ -1,7 +1,6 @@
 package rulekit
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 )
@@ -12,15 +11,35 @@ type FunctionValue struct {
 }
 
 func (f *FunctionValue) Eval(ctx *Ctx) Result {
-	// WIP testing function parsing
-	fmt.Printf("%s(...)\n", f.fn)
-	for _, arg := range f.args.vals {
-		fmt.Printf(": %T %s\n", arg, arg.String())
+	var fn *Function
+	if stdlibFn, ok := StdlibFuncs[f.fn]; ok {
+		fn = stdlibFn
+	} else {
+		return Result{
+			Error:         fmt.Errorf("unknown function %q", f.fn),
+			EvaluatedRule: f,
+		}
 	}
-	return Result{
-		Error:         errors.New("not implemented"),
-		EvaluatedRule: f,
+
+	// if args are set, validate them
+	if len(fn.Args) != len(f.args.vals) {
+		return Result{
+			Error:         fmt.Errorf("function %q expects %d arguments, got %d", f.fn, len(fn.Args), len(f.args.vals)),
+			EvaluatedRule: f,
+		}
 	}
+
+	argMap := make(map[string]any, len(f.args.vals))
+	for i, arg := range f.args.vals {
+		res := arg.Eval(ctx)
+		if !res.Ok() {
+			return res
+		}
+		argMap[fn.Args[i].Name] = res.Value
+	}
+	res := fn.Eval(argMap)
+	res.EvaluatedRule = f
+	return res
 }
 
 func (f *FunctionValue) String() string {
@@ -34,4 +53,46 @@ func newFunctionValue(fn string, args *ArrayValue) *FunctionValue {
 		fn:   fn,
 		args: args,
 	}
+}
+
+func (f *FunctionValue) ValidateStdlibFnArgs() error {
+	if stdlibFn, ok := StdlibFuncs[f.fn]; ok {
+		if len(stdlibFn.Args) != len(f.args.vals) {
+			return fmt.Errorf("function %q expects %d arguments, got %d", f.fn, len(stdlibFn.Args), len(f.args.vals))
+		}
+	}
+	return nil
+}
+
+type Function struct {
+	Name string
+	// Args is an optional list of arguments that the function expects.
+	// If set, rulekit will ensure validity of the arguments and pass them as a named map to the Eval function.
+	Args []FunctionArg
+	// Eval is the function that will be called with the arguments.
+	// EvaluatedRule will be set by Rulekit.
+	Eval func(map[string]any) Result
+}
+
+type FunctionArg struct {
+	Name string
+	Type string
+}
+
+func IndexFnArg[T any](args map[string]any, idx int, name string) (T, error) {
+	var zeroVal T
+
+	valAny, ok := args[name]
+	if !ok {
+		return zeroVal, fmt.Errorf("unrecognized argument name %q", name)
+	}
+	val, ok := valAny.(T)
+	if !ok {
+		return zeroVal, &ErrInvalidFunctionArg{
+			Index:    idx,
+			Expected: fmt.Sprintf("%T", valAny),
+			Got:      fmt.Sprintf("%T", valAny),
+		}
+	}
+	return val, nil
 }

--- a/functions.go
+++ b/functions.go
@@ -1,0 +1,37 @@
+package rulekit
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type FunctionValue struct {
+	fn   string
+	args *ArrayValue
+}
+
+func (f *FunctionValue) Eval(ctx *Ctx) Result {
+	// WIP testing function parsing
+	fmt.Printf("%s(...)\n", f.fn)
+	for _, arg := range f.args.vals {
+		fmt.Printf(": %T %s\n", arg, arg.String())
+	}
+	return Result{
+		Error:         errors.New("not implemented"),
+		EvaluatedRule: f,
+	}
+}
+
+func (f *FunctionValue) String() string {
+	return f.fn + "(" + f.args.String() + ")"
+}
+
+func newFunctionValue(fn string, args *ArrayValue) *FunctionValue {
+	args.raw = strings.TrimPrefix(args.raw, "[")
+	args.raw = strings.TrimSuffix(args.raw, "]")
+	return &FunctionValue{
+		fn:   fn,
+		args: args,
+	}
+}

--- a/functions.go
+++ b/functions.go
@@ -43,12 +43,13 @@ func (f *FunctionValue) String() string {
 	return f.fn + "(" + f.args.String() + ")"
 }
 
-func newFunctionValue(fn string, args *ArrayValue) *FunctionValue {
-	args.raw = strings.TrimPrefix(args.raw, "[")
-	args.raw = strings.TrimSuffix(args.raw, "]")
+func newFunctionValue(fn string, args []Rule) *FunctionValue {
+	argsArr := newArrayValue(args)
+	argsArr.raw = strings.TrimPrefix(argsArr.raw, "[")
+	argsArr.raw = strings.TrimSuffix(argsArr.raw, "]")
 	return &FunctionValue{
 		fn:   fn,
-		args: args,
+		args: argsArr,
 	}
 }
 

--- a/functions.go
+++ b/functions.go
@@ -11,17 +11,14 @@ type FunctionValue struct {
 }
 
 func (f *FunctionValue) Eval(ctx *Ctx) Result {
-	var fn *Function
-	if stdlibFn, ok := StdlibFuncs[f.fn]; ok {
-		fn = stdlibFn
-	} else {
+	fn, ok := StdlibFuncs[f.fn]
+	if !ok {
 		return Result{
 			Error:         fmt.Errorf("unknown function %q", f.fn),
 			EvaluatedRule: f,
 		}
 	}
 
-	// if args are set, validate them
 	if len(fn.Args) != len(f.args.vals) {
 		return Result{
 			Error:         fmt.Errorf("function %q expects %d arguments, got %d", f.fn, len(fn.Args), len(f.args.vals)),
@@ -65,7 +62,6 @@ func (f *FunctionValue) ValidateStdlibFnArgs() error {
 }
 
 type Function struct {
-	Name string
 	// Args is an optional list of arguments that the function expects.
 	// If set, rulekit will ensure validity of the arguments and pass them as a named map to the Eval function.
 	Args []FunctionArg

--- a/functions_stdlib.go
+++ b/functions_stdlib.go
@@ -1,27 +1,29 @@
 package rulekit
 
 import (
+	"fmt"
 	"strings"
 )
 
 var StdlibFuncs = map[string]*Function{
 	"starts_with": {
-		Name: "starts_with",
 		Args: []FunctionArg{
-			{Name: "str"},
+			{Name: "value"},
 			{Name: "prefix"},
 		},
 		Eval: func(args map[string]any) Result {
-			str, err := IndexFnArg[string](args, 0, "str")
+			value, err := IndexFnArg[any](args, 0, "value")
 			if err != nil {
 				return Result{Error: err}
 			}
-			prefix, err := IndexFnArg[string](args, 1, "prefix")
+			prefix, err := IndexFnArg[any](args, 1, "prefix")
 			if err != nil {
 				return Result{Error: err}
 			}
 
-			return Result{Value: strings.HasPrefix(str, prefix)}
+			return Result{
+				Value: strings.HasPrefix(fmt.Sprint(value), fmt.Sprint(prefix)),
+			}
 		},
 	},
 }

--- a/functions_stdlib.go
+++ b/functions_stdlib.go
@@ -1,0 +1,27 @@
+package rulekit
+
+import (
+	"strings"
+)
+
+var StdlibFuncs = map[string]*Function{
+	"starts_with": {
+		Name: "starts_with",
+		Args: []FunctionArg{
+			{Name: "str"},
+			{Name: "prefix"},
+		},
+		Eval: func(args map[string]any) Result {
+			str, err := IndexFnArg[string](args, 0, "str")
+			if err != nil {
+				return Result{Error: err}
+			}
+			prefix, err := IndexFnArg[string](args, 1, "prefix")
+			if err != nil {
+				return Result{Error: err}
+			}
+
+			return Result{Value: strings.HasPrefix(str, prefix)}
+		},
+	},
+}

--- a/functions_stdlib_test.go
+++ b/functions_stdlib_test.go
@@ -27,6 +27,7 @@ func TestFn_StartsWith(t *testing.T) {
 	assertRulep(t, `starts_with(code, 5)`, kv{"code": 500}).Pass()
 	assertRulep(t, `starts_with(code, "5")`, kv{"code": 500}).Pass()
 	assertRulep(t, `starts_with(code, 5)`, kv{"code": 404}).Fail()
+	assertRulep(t, `starts_with(starts_with("https://example.com", "https://"), "true")`, nil).Pass()
 
 	// parser errors
 	assertParseErrorValue(t, "starts_with()", `syntax error at line 1:14:

--- a/functions_stdlib_test.go
+++ b/functions_stdlib_test.go
@@ -2,6 +2,7 @@ package rulekit
 
 import (
 	"errors"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -17,11 +18,17 @@ func TestFn_InvalidArgs(t *testing.T) {
 
 func TestFn_StartsWith(t *testing.T) {
 	r := MustParse(`starts_with(url, "https://")`)
-
 	assertRule(t, r, kv{"url": "https://example.com"}).Pass()
 	assertRule(t, r, kv{"url": "http://example.com"}).Fail()
 	assertRule(t, r, kv{"url": "invalid-url"}).Fail()
 
+	// non-string args
+	assertRulep(t, `starts_with(ip, "10.0")`, kv{"ip": net.ParseIP("10.0.0.1")}).Pass()
+	assertRulep(t, `starts_with(code, 5)`, kv{"code": 500}).Pass()
+	assertRulep(t, `starts_with(code, "5")`, kv{"code": 500}).Pass()
+	assertRulep(t, `starts_with(code, 5)`, kv{"code": 404}).Fail()
+
+	// parser errors
 	assertParseErrorValue(t, "starts_with()", `syntax error at line 1:14:
 starts_with()
              ^

--- a/functions_stdlib_test.go
+++ b/functions_stdlib_test.go
@@ -1,0 +1,33 @@
+package rulekit
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFn_InvalidArgs(t *testing.T) {
+	_, err := Parse("some_none_stdlib_fn()")
+	require.NoError(t, err)
+
+	assertRulep(t, "unknown_fn()", nil).Error(errors.New(`unknown function "unknown_fn"`))
+	assertRulep(t, "unknown_fn(some_args)", nil).Error(errors.New(`unknown function "unknown_fn"`))
+}
+
+func TestFn_StartsWith(t *testing.T) {
+	r := MustParse(`starts_with(url, "https://")`)
+
+	assertRule(t, r, kv{"url": "https://example.com"}).Pass()
+	assertRule(t, r, kv{"url": "http://example.com"}).Fail()
+	assertRule(t, r, kv{"url": "invalid-url"}).Fail()
+
+	assertParseErrorValue(t, "starts_with()", `syntax error at line 1:14:
+starts_with()
+             ^
+function "starts_with" expects 2 arguments, got 0`)
+	assertParseErrorValue(t, "starts_with(arg1)", `syntax error at line 1:18:
+starts_with(arg1)
+                 ^
+function "starts_with" expects 2 arguments, got 1`)
+}

--- a/lexer.go
+++ b/lexer.go
@@ -18,15 +18,15 @@ var _ruleLexerImpl_actions []byte = []byte{
 	1, 46, 1, 47, 1, 48, 1, 49,
 	1, 50, 1, 51, 1, 52, 1, 53,
 	1, 54, 1, 55, 1, 56, 1, 57,
-	2, 2, 3, 2, 2, 4, 2, 2,
-	5, 2, 2, 6, 2, 2, 7, 2,
-	2, 8, 2, 2, 9, 2, 2, 10,
-	2, 2, 11, 2, 2, 12, 2, 2,
-	13, 2, 2, 14, 2, 2, 15, 2,
-	2, 16, 2, 2, 17, 2, 2, 18,
-	2, 2, 19, 2, 2, 20, 2, 2,
-	21, 2, 2, 22, 2, 2, 23, 2,
-	2, 24,
+	1, 58, 2, 2, 3, 2, 2, 4,
+	2, 2, 5, 2, 2, 6, 2, 2,
+	7, 2, 2, 8, 2, 2, 9, 2,
+	2, 10, 2, 2, 11, 2, 2, 12,
+	2, 2, 13, 2, 2, 14, 2, 2,
+	15, 2, 2, 16, 2, 2, 17, 2,
+	2, 18, 2, 2, 19, 2, 2, 20,
+	2, 2, 21, 2, 2, 22, 2, 2,
+	23, 2, 2, 24,
 }
 
 var _ruleLexerImpl_key_offsets []int16 = []int16{
@@ -59,10 +59,10 @@ var _ruleLexerImpl_key_offsets []int16 = []int16{
 	1404, 1412, 1420, 1421, 1431, 1440, 1448, 1456,
 	1458, 1467, 1476, 1485, 1497, 1508, 1517, 1526,
 	1534, 1535, 1537, 1538, 1553, 1561, 1574, 1587,
-	1596, 1606, 1619, 1634, 1644, 1654, 1664, 1674,
-	1684, 1694, 1709, 1724, 1739, 1749, 1759, 1771,
-	1781, 1793, 1803, 1813, 1823, 1833, 1843, 1853,
-	1865, 1875, 1885, 1895, 1905,
+	1596, 1604, 1614, 1627, 1642, 1652, 1662, 1672,
+	1682, 1692, 1702, 1717, 1732, 1747, 1757, 1767,
+	1779, 1789, 1801, 1811, 1821, 1831, 1841, 1851,
+	1861, 1873, 1883, 1893, 1903, 1913,
 }
 
 var _ruleLexerImpl_trans_keys []byte = []byte{
@@ -265,6 +265,7 @@ var _ruleLexerImpl_trans_keys []byte = []byte{
 	71, 90, 97, 102, 103, 122, 46, 58,
 	95, 48, 57, 65, 70, 71, 90, 97,
 	102, 103, 122, 46, 58, 95, 48, 57,
+	65, 90, 97, 122, 46, 95, 48, 57,
 	65, 90, 97, 122, 46, 68, 95, 100,
 	48, 57, 65, 90, 97, 122, 46, 58,
 	95, 48, 57, 65, 70, 71, 90, 97,
@@ -337,10 +338,10 @@ var _ruleLexerImpl_single_lengths []byte = []byte{
 	2, 2, 1, 4, 3, 2, 2, 2,
 	3, 3, 3, 4, 3, 3, 3, 2,
 	1, 2, 1, 5, 2, 3, 3, 3,
-	4, 3, 5, 4, 4, 4, 4, 4,
-	4, 5, 5, 5, 4, 4, 6, 4,
-	6, 4, 4, 4, 4, 4, 4, 6,
-	4, 4, 4, 4, 2,
+	2, 4, 3, 5, 4, 4, 4, 4,
+	4, 4, 5, 5, 5, 4, 4, 6,
+	4, 6, 4, 4, 4, 4, 4, 4,
+	6, 4, 4, 4, 4, 2,
 }
 
 var _ruleLexerImpl_range_lengths []byte = []byte{
@@ -373,10 +374,10 @@ var _ruleLexerImpl_range_lengths []byte = []byte{
 	3, 3, 0, 3, 3, 3, 3, 0,
 	3, 3, 3, 4, 4, 3, 3, 3,
 	0, 0, 0, 5, 3, 5, 5, 3,
-	3, 5, 5, 3, 3, 3, 3, 3,
-	3, 5, 5, 5, 3, 3, 3, 3,
+	3, 3, 5, 5, 3, 3, 3, 3,
+	3, 3, 5, 5, 5, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3,
-	3, 3, 3, 3, 0,
+	3, 3, 3, 3, 3, 0,
 }
 
 var _ruleLexerImpl_index_offsets []int16 = []int16{
@@ -409,10 +410,10 @@ var _ruleLexerImpl_index_offsets []int16 = []int16{
 	1128, 1134, 1140, 1142, 1150, 1157, 1163, 1169,
 	1172, 1179, 1186, 1193, 1202, 1210, 1217, 1224,
 	1230, 1232, 1235, 1237, 1248, 1254, 1263, 1272,
-	1279, 1287, 1296, 1307, 1315, 1323, 1331, 1339,
-	1347, 1355, 1366, 1377, 1388, 1396, 1404, 1414,
-	1422, 1432, 1440, 1448, 1456, 1464, 1472, 1480,
-	1490, 1498, 1506, 1514, 1522,
+	1279, 1285, 1293, 1302, 1313, 1321, 1329, 1337,
+	1345, 1353, 1361, 1372, 1383, 1394, 1402, 1410,
+	1420, 1428, 1438, 1446, 1454, 1462, 1470, 1478,
+	1486, 1496, 1504, 1512, 1520, 1528,
 }
 
 var _ruleLexerImpl_indicies []int16 = []int16{
@@ -570,43 +571,44 @@ var _ruleLexerImpl_indicies []int16 = []int16{
 	264, 191, 73, 192, 263, 264, 264, 264,
 	191, 73, 192, 263, 269, 262, 262, 191,
 	192, 263, 262, 262, 262, 191, 271, 270,
-	272, 273, 180, 275, 274, 168, 109, 278,
-	168, 278, 277, 277, 168, 277, 168, 276,
-	168, 168, 168, 168, 168, 0, 168, 198,
-	168, 279, 279, 168, 279, 168, 243, 168,
-	109, 168, 280, 280, 168, 280, 168, 276,
-	168, 109, 168, 168, 168, 168, 276, 168,
-	281, 168, 281, 168, 168, 168, 276, 168,
-	109, 168, 277, 277, 168, 277, 168, 276,
-	168, 109, 282, 168, 282, 277, 277, 168,
-	277, 168, 276, 168, 283, 168, 283, 168,
-	168, 168, 276, 168, 284, 168, 284, 168,
-	168, 168, 276, 168, 285, 168, 285, 168,
-	168, 168, 276, 168, 286, 168, 286, 168,
-	168, 168, 276, 168, 287, 168, 287, 168,
-	168, 168, 276, 168, 288, 168, 288, 168,
-	168, 168, 276, 168, 109, 289, 168, 289,
-	277, 277, 168, 277, 168, 276, 168, 109,
-	290, 168, 290, 277, 277, 168, 277, 168,
-	276, 168, 198, 291, 168, 291, 279, 279,
-	168, 279, 168, 243, 168, 292, 168, 292,
-	168, 168, 168, 276, 168, 293, 168, 293,
-	168, 168, 168, 276, 168, 294, 295, 168,
-	294, 295, 168, 168, 168, 276, 168, 296,
-	168, 296, 168, 168, 168, 276, 168, 297,
-	298, 168, 297, 298, 168, 168, 168, 276,
-	168, 299, 168, 299, 168, 168, 168, 276,
-	168, 300, 168, 300, 168, 168, 168, 276,
-	168, 301, 168, 301, 168, 168, 168, 276,
-	168, 302, 168, 302, 168, 168, 168, 276,
-	168, 303, 168, 303, 168, 168, 168, 276,
-	168, 304, 168, 304, 168, 168, 168, 276,
-	168, 305, 306, 168, 305, 306, 168, 168,
-	168, 276, 168, 307, 168, 307, 168, 168,
-	168, 276, 168, 308, 168, 308, 168, 168,
-	168, 276, 168, 309, 168, 309, 168, 168,
-	168, 276, 168, 292, 168, 292, 168, 168,
-	168, 276, 140, 310, 139,
+	272, 273, 180, 275, 274, 277, 109, 279,
+	168, 279, 278, 278, 168, 278, 168, 276,
+	277, 277, 277, 277, 277, 280, 277, 198,
+	168, 281, 281, 168, 281, 168, 243, 277,
+	109, 168, 282, 282, 168, 282, 168, 276,
+	277, 109, 168, 168, 168, 168, 276, 277,
+	168, 168, 168, 168, 0, 277, 283, 168,
+	283, 168, 168, 168, 276, 277, 109, 168,
+	278, 278, 168, 278, 168, 276, 277, 109,
+	284, 168, 284, 278, 278, 168, 278, 168,
+	276, 277, 285, 168, 285, 168, 168, 168,
+	276, 277, 286, 168, 286, 168, 168, 168,
+	276, 277, 287, 168, 287, 168, 168, 168,
+	276, 277, 288, 168, 288, 168, 168, 168,
+	276, 277, 289, 168, 289, 168, 168, 168,
+	276, 277, 290, 168, 290, 168, 168, 168,
+	276, 277, 109, 291, 168, 291, 278, 278,
+	168, 278, 168, 276, 277, 109, 292, 168,
+	292, 278, 278, 168, 278, 168, 276, 277,
+	198, 293, 168, 293, 281, 281, 168, 281,
+	168, 243, 277, 294, 168, 294, 168, 168,
+	168, 276, 277, 295, 168, 295, 168, 168,
+	168, 276, 277, 296, 297, 168, 296, 297,
+	168, 168, 168, 276, 277, 298, 168, 298,
+	168, 168, 168, 276, 277, 299, 300, 168,
+	299, 300, 168, 168, 168, 276, 277, 301,
+	168, 301, 168, 168, 168, 276, 277, 302,
+	168, 302, 168, 168, 168, 276, 277, 303,
+	168, 303, 168, 168, 168, 276, 277, 304,
+	168, 304, 168, 168, 168, 276, 277, 305,
+	168, 305, 168, 168, 168, 276, 277, 306,
+	168, 306, 168, 168, 168, 276, 277, 307,
+	308, 168, 307, 308, 168, 168, 168, 276,
+	277, 309, 168, 309, 168, 168, 168, 276,
+	277, 310, 168, 310, 168, 168, 168, 276,
+	277, 311, 168, 311, 168, 168, 168, 276,
+	277, 294, 168, 294, 168, 168, 168, 276,
+	140, 312, 139,
 }
 
 var _ruleLexerImpl_trans_targs []int16 = []int16{
@@ -630,9 +632,9 @@ var _ruleLexerImpl_trans_targs []int16 = []int16{
 	185, 188, 189, 93, 94, 95, 95, 96,
 	97, 98, 99, 95, 95, 100, 95, 102,
 	101, 104, 106, 203, 206, 209, 210, 224,
-	225, 226, 227, 233, 234, 241, 242, 246,
-	228, 247, 248, 249, 255, 257, 258, 95,
-	95, 260, 95, 95, 95, 95, 4, 100,
+	225, 226, 227, 234, 235, 242, 243, 247,
+	232, 248, 249, 250, 256, 258, 259, 95,
+	95, 261, 95, 95, 95, 95, 4, 100,
 	103, 95, 95, 12, 118, 202, 95, 95,
 	16, 95, 95, 113, 117, 119, 72, 91,
 	120, 122, 123, 127, 66, 128, 129, 131,
@@ -644,53 +646,55 @@ var _ruleLexerImpl_trans_targs []int16 = []int16{
 	82, 84, 197, 85, 204, 205, 207, 208,
 	211, 212, 216, 219, 222, 223, 213, 92,
 	214, 215, 217, 218, 220, 221, 95, 95,
-	95, 95, 95, 95, 95, 229, 232, 230,
-	231, 228, 235, 236, 237, 238, 239, 240,
-	228, 228, 243, 244, 245, 228, 228, 228,
-	228, 228, 228, 250, 251, 252, 253, 254,
-	228, 228, 256, 228, 228, 259, 95,
+	95, 95, 95, 95, 95, 228, 229, 233,
+	95, 230, 231, 232, 236, 237, 238, 239,
+	240, 241, 232, 232, 244, 245, 246, 232,
+	232, 232, 232, 232, 232, 251, 252, 253,
+	254, 255, 232, 232, 257, 232, 232, 260,
+	95,
 }
 
 var _ruleLexerImpl_trans_actions []byte = []byte{
-	71, 0, 33, 0, 121, 0, 0, 121,
-	115, 69, 0, 37, 0, 0, 0, 130,
-	0, 73, 0, 0, 63, 115, 115, 115,
-	115, 0, 0, 0, 0, 0, 5, 5,
-	5, 5, 65, 0, 0, 0, 5, 0,
+	73, 0, 33, 0, 123, 0, 0, 123,
+	117, 71, 0, 37, 0, 0, 0, 132,
+	0, 75, 0, 0, 65, 117, 117, 117,
+	117, 0, 0, 0, 0, 0, 5, 5,
+	5, 5, 67, 0, 0, 0, 5, 0,
 	0, 0, 0, 0, 5, 0, 0, 0,
 	0, 0, 5, 0, 0, 0, 0, 0,
 	5, 0, 0, 0, 0, 0, 5, 0,
 	0, 0, 0, 0, 0, 0, 0, 5,
 	0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 5, 0, 0, 0,
-	0, 124, 124, 124, 124, 5, 124, 124,
-	124, 124, 5, 124, 124, 124, 124, 5,
-	124, 124, 124, 124, 5, 0, 0, 127,
-	67, 0, 127, 0, 127, 0, 127, 0,
-	127, 0, 0, 0, 0, 0, 127, 5,
-	0, 127, 127, 127, 127, 0, 124, 124,
-	124, 124, 5, 0, 0, 39, 7, 0,
-	136, 0, 136, 9, 11, 136, 17, 136,
-	136, 5, 112, 112, 112, 112, 0, 0,
-	0, 0, 133, 133, 133, 133, 133, 0,
-	133, 0, 0, 0, 0, 0, 0, 13,
-	15, 5, 43, 25, 61, 19, 0, 112,
-	0, 41, 49, 0, 112, 127, 51, 53,
-	0, 55, 35, 5, 115, 112, 0, 0,
-	112, 5, 5, 5, 0, 5, 5, 124,
-	124, 124, 124, 5, 0, 5, 5, 124,
-	124, 124, 124, 5, 0, 5, 5, 124,
-	124, 124, 124, 5, 0, 5, 5, 124,
-	124, 124, 124, 5, 0, 5, 5, 124,
-	124, 124, 124, 57, 0, 0, 0, 0,
-	0, 0, 124, 0, 112, 112, 112, 112,
-	5, 124, 124, 124, 124, 5, 5, 0,
-	5, 5, 124, 124, 124, 124, 45, 27,
-	23, 31, 47, 29, 59, 127, 0, 133,
-	133, 79, 0, 0, 0, 0, 0, 0,
-	103, 85, 127, 0, 0, 118, 100, 97,
-	109, 94, 91, 0, 0, 0, 0, 0,
-	106, 88, 0, 76, 82, 0, 21,
+	0, 126, 126, 126, 126, 5, 126, 126,
+	126, 126, 5, 126, 126, 126, 126, 5,
+	126, 126, 126, 126, 5, 0, 0, 129,
+	69, 0, 129, 0, 129, 0, 129, 0,
+	129, 0, 0, 0, 0, 0, 129, 5,
+	0, 129, 129, 129, 129, 0, 126, 126,
+	126, 126, 5, 0, 0, 39, 7, 0,
+	138, 0, 138, 9, 11, 138, 17, 138,
+	138, 5, 114, 114, 114, 114, 0, 0,
+	0, 0, 135, 135, 135, 135, 135, 0,
+	135, 0, 0, 0, 0, 0, 0, 13,
+	15, 5, 43, 25, 63, 19, 0, 114,
+	0, 41, 49, 0, 114, 129, 51, 53,
+	0, 55, 35, 5, 117, 114, 0, 0,
+	114, 5, 5, 5, 0, 5, 5, 126,
+	126, 126, 126, 5, 0, 5, 5, 126,
+	126, 126, 126, 5, 0, 5, 5, 126,
+	126, 126, 126, 5, 0, 5, 5, 126,
+	126, 126, 126, 5, 0, 5, 5, 126,
+	126, 126, 126, 57, 0, 0, 0, 0,
+	0, 0, 126, 0, 114, 114, 114, 114,
+	5, 126, 126, 126, 126, 5, 5, 0,
+	5, 5, 126, 126, 126, 126, 45, 27,
+	23, 31, 47, 29, 59, 0, 129, 0,
+	61, 135, 135, 81, 0, 0, 0, 0,
+	0, 0, 105, 87, 129, 0, 0, 120,
+	102, 99, 111, 96, 93, 0, 0, 0,
+	0, 0, 108, 90, 0, 78, 84, 0,
+	21,
 }
 
 var _ruleLexerImpl_to_state_actions []byte = []byte{
@@ -726,7 +730,7 @@ var _ruleLexerImpl_to_state_actions []byte = []byte{
 	0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0,
 }
 
 var _ruleLexerImpl_from_state_actions []byte = []byte{
@@ -762,7 +766,7 @@ var _ruleLexerImpl_from_state_actions []byte = []byte{
 	0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0,
 }
 
 var _ruleLexerImpl_eof_trans []int16 = []int16{
@@ -794,11 +798,11 @@ var _ruleLexerImpl_eof_trans []int16 = []int16{
 	244, 244, 244, 187, 187, 187, 187, 187,
 	187, 187, 181, 192, 192, 192, 192, 192,
 	192, 192, 192, 192, 192, 192, 192, 192,
-	271, 181, 275, 277, 1, 244, 277, 277,
+	271, 181, 275, 277, 281, 244, 277, 277,
+	1, 277, 277, 277, 277, 277, 277, 277,
+	277, 277, 277, 277, 244, 277, 277, 277,
 	277, 277, 277, 277, 277, 277, 277, 277,
-	277, 277, 277, 244, 277, 277, 277, 277,
-	277, 277, 277, 277, 277, 277, 277, 277,
-	277, 277, 277, 277, 181,
+	277, 277, 277, 277, 277, 181,
 }
 
 const ruleLexerImpl_start int = 95
@@ -807,7 +811,7 @@ const ruleLexerImpl_error int = -1
 
 const ruleLexerImpl_en_main int = 95
 
-//line lexer.rl:134
+//line lexer.rl:140
 
 type ruleLexerImpl struct {
 	data   []byte
@@ -825,7 +829,7 @@ type ruleLexerImpl struct {
 func newLex(line []byte) *ruleLexerImpl {
 	lexer := ruleLexerImpl{data: line}
 
-//line lexer.go:831
+//line lexer.go:835
 	{
 		(lexer.cs) = ruleLexerImpl_start
 		(lexer.ts) = 0
@@ -833,7 +837,7 @@ func newLex(line []byte) *ruleLexerImpl {
 		(lexer.act) = 0
 	}
 
-//line lexer.rl:152
+//line lexer.rl:158
 	lexer.pe = len(line)
 	lexer.eof = len(line)
 	return &lexer
@@ -842,7 +846,7 @@ func newLex(line []byte) *ruleLexerImpl {
 func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 	token_kind := 0
 
-//line lexer.go:848
+//line lexer.go:852
 	{
 		var _klen int
 		var _trans int
@@ -863,7 +867,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 //line NONE:1
 				(lexer.ts) = (lexer.p)
 
-//line lexer.go:868
+//line lexer.go:872
 			}
 		}
 
@@ -939,78 +943,78 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 				(lexer.te) = (lexer.p) + 1
 
 			case 3:
-//line lexer.rl:77
+//line lexer.rl:81
 				(lexer.act) = 1
 			case 4:
-//line lexer.rl:87
+//line lexer.rl:91
 				(lexer.act) = 7
 			case 5:
-//line lexer.rl:88
+//line lexer.rl:92
 				(lexer.act) = 8
 			case 6:
-//line lexer.rl:89
+//line lexer.rl:93
 				(lexer.act) = 9
 			case 7:
-//line lexer.rl:92
+//line lexer.rl:96
 				(lexer.act) = 10
 			case 8:
-//line lexer.rl:93
+//line lexer.rl:97
 				(lexer.act) = 11
 			case 9:
-//line lexer.rl:94
+//line lexer.rl:98
 				(lexer.act) = 12
 			case 10:
-//line lexer.rl:95
+//line lexer.rl:99
 				(lexer.act) = 13
 			case 11:
-//line lexer.rl:96
+//line lexer.rl:100
 				(lexer.act) = 14
 			case 12:
-//line lexer.rl:97
+//line lexer.rl:101
 				(lexer.act) = 15
 			case 13:
-//line lexer.rl:99
+//line lexer.rl:103
 				(lexer.act) = 16
 			case 14:
-//line lexer.rl:100
+//line lexer.rl:104
 				(lexer.act) = 17
 			case 15:
-//line lexer.rl:101
+//line lexer.rl:105
 				(lexer.act) = 18
 			case 16:
-//line lexer.rl:104
+//line lexer.rl:108
 				(lexer.act) = 19
 			case 17:
-//line lexer.rl:105
+//line lexer.rl:109
 				(lexer.act) = 20
 			case 18:
-//line lexer.rl:106
+//line lexer.rl:110
 				(lexer.act) = 21
 			case 19:
-//line lexer.rl:107
+//line lexer.rl:111
 				(lexer.act) = 22
 			case 20:
-//line lexer.rl:109
+//line lexer.rl:113
 				(lexer.act) = 23
 			case 21:
-//line lexer.rl:111
+//line lexer.rl:115
 				(lexer.act) = 25
 			case 22:
-//line lexer.rl:112
+//line lexer.rl:116
 				(lexer.act) = 26
 			case 23:
-//line lexer.rl:115
+//line lexer.rl:118
 				(lexer.act) = 27
 			case 24:
-//line lexer.rl:118
-				(lexer.act) = 28
+//line lexer.rl:124
+				(lexer.act) = 29
 			case 25:
-//line lexer.rl:77
+//line lexer.rl:81
 				(lexer.te) = (lexer.p) + 1
 				{ /* skip */
 				}
 			case 26:
-//line lexer.rl:80
+//line lexer.rl:84
 				(lexer.te) = (lexer.p) + 1
 				{
 					token_kind = token_LPAREN
@@ -1018,7 +1022,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					goto _out
 				}
 			case 27:
-//line lexer.rl:81
+//line lexer.rl:85
 				(lexer.te) = (lexer.p) + 1
 				{
 					token_kind = token_RPAREN
@@ -1026,7 +1030,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					goto _out
 				}
 			case 28:
-//line lexer.rl:82
+//line lexer.rl:86
 				(lexer.te) = (lexer.p) + 1
 				{
 					token_kind = token_LBRACKET
@@ -1034,7 +1038,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					goto _out
 				}
 			case 29:
-//line lexer.rl:83
+//line lexer.rl:87
 				(lexer.te) = (lexer.p) + 1
 				{
 					token_kind = token_RBRACKET
@@ -1042,7 +1046,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					goto _out
 				}
 			case 30:
-//line lexer.rl:84
+//line lexer.rl:88
 				(lexer.te) = (lexer.p) + 1
 				{
 					token_kind = token_COMMA
@@ -1050,7 +1054,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					goto _out
 				}
 			case 31:
-//line lexer.rl:88
+//line lexer.rl:92
 				(lexer.te) = (lexer.p) + 1
 				{
 					token_kind = op_AND
@@ -1058,7 +1062,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					goto _out
 				}
 			case 32:
-//line lexer.rl:89
+//line lexer.rl:93
 				(lexer.te) = (lexer.p) + 1
 				{
 					token_kind = op_OR
@@ -1066,7 +1070,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					goto _out
 				}
 			case 33:
-//line lexer.rl:92
+//line lexer.rl:96
 				(lexer.te) = (lexer.p) + 1
 				{
 					token_kind = op_EQ
@@ -1074,7 +1078,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					goto _out
 				}
 			case 34:
-//line lexer.rl:93
+//line lexer.rl:97
 				(lexer.te) = (lexer.p) + 1
 				{
 					token_kind = op_NE
@@ -1082,7 +1086,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					goto _out
 				}
 			case 35:
-//line lexer.rl:95
+//line lexer.rl:99
 				(lexer.te) = (lexer.p) + 1
 				{
 					token_kind = op_LE
@@ -1090,7 +1094,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					goto _out
 				}
 			case 36:
-//line lexer.rl:97
+//line lexer.rl:101
 				(lexer.te) = (lexer.p) + 1
 				{
 					token_kind = op_GE
@@ -1098,7 +1102,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					goto _out
 				}
 			case 37:
-//line lexer.rl:100
+//line lexer.rl:104
 				(lexer.te) = (lexer.p) + 1
 				{
 					token_kind = op_MATCHES
@@ -1106,7 +1110,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					goto _out
 				}
 			case 38:
-//line lexer.rl:107
+//line lexer.rl:111
 				(lexer.te) = (lexer.p) + 1
 				{
 					token_kind = token_STRING
@@ -1114,7 +1118,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					goto _out
 				}
 			case 39:
-//line lexer.rl:110
+//line lexer.rl:114
 				(lexer.te) = (lexer.p) + 1
 				{
 					token_kind = token_IP_CIDR
@@ -1122,7 +1126,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					goto _out
 				}
 			case 40:
-//line lexer.rl:112
+//line lexer.rl:116
 				(lexer.te) = (lexer.p) + 1
 				{
 					token_kind = token_REGEX
@@ -1130,20 +1134,20 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					goto _out
 				}
 			case 41:
-//line lexer.rl:118
+//line lexer.rl:124
 				(lexer.te) = (lexer.p) + 1
 				{
 					lexer.Error(fmt.Sprintf("unexpected character: %q", safeIndex(lexer.data, lexer.ts, lexer.te)))
 					return token_ERROR
 				}
 			case 42:
-//line lexer.rl:77
+//line lexer.rl:81
 				(lexer.te) = (lexer.p)
 				(lexer.p)--
 				{ /* skip */
 				}
 			case 43:
-//line lexer.rl:87
+//line lexer.rl:91
 				(lexer.te) = (lexer.p)
 				(lexer.p)--
 				{
@@ -1152,7 +1156,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					goto _out
 				}
 			case 44:
-//line lexer.rl:94
+//line lexer.rl:98
 				(lexer.te) = (lexer.p)
 				(lexer.p)--
 				{
@@ -1161,7 +1165,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					goto _out
 				}
 			case 45:
-//line lexer.rl:96
+//line lexer.rl:100
 				(lexer.te) = (lexer.p)
 				(lexer.p)--
 				{
@@ -1170,7 +1174,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					goto _out
 				}
 			case 46:
-//line lexer.rl:104
+//line lexer.rl:108
 				(lexer.te) = (lexer.p)
 				(lexer.p)--
 				{
@@ -1179,7 +1183,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					goto _out
 				}
 			case 47:
-//line lexer.rl:105
+//line lexer.rl:109
 				(lexer.te) = (lexer.p)
 				(lexer.p)--
 				{
@@ -1188,7 +1192,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					goto _out
 				}
 			case 48:
-//line lexer.rl:109
+//line lexer.rl:113
 				(lexer.te) = (lexer.p)
 				(lexer.p)--
 				{
@@ -1197,7 +1201,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					goto _out
 				}
 			case 49:
-//line lexer.rl:110
+//line lexer.rl:114
 				(lexer.te) = (lexer.p)
 				(lexer.p)--
 				{
@@ -1206,7 +1210,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					goto _out
 				}
 			case 50:
-//line lexer.rl:111
+//line lexer.rl:115
 				(lexer.te) = (lexer.p)
 				(lexer.p)--
 				{
@@ -1215,7 +1219,16 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					goto _out
 				}
 			case 51:
-//line lexer.rl:115
+//line lexer.rl:118
+				(lexer.te) = (lexer.p)
+				(lexer.p)--
+				{
+					token_kind = token_FUNCTION
+					(lexer.p)++
+					goto _out
+				}
+			case 52:
+//line lexer.rl:121
 				(lexer.te) = (lexer.p)
 				(lexer.p)--
 				{
@@ -1223,46 +1236,46 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					(lexer.p)++
 					goto _out
 				}
-			case 52:
-//line lexer.rl:118
+			case 53:
+//line lexer.rl:124
 				(lexer.te) = (lexer.p)
 				(lexer.p)--
 				{
 					lexer.Error(fmt.Sprintf("unexpected character: %q", safeIndex(lexer.data, lexer.ts, lexer.te)))
 					return token_ERROR
 				}
-			case 53:
-//line lexer.rl:104
+			case 54:
+//line lexer.rl:108
 				(lexer.p) = (lexer.te) - 1
 				{
 					token_kind = token_INT
 					(lexer.p)++
 					goto _out
 				}
-			case 54:
-//line lexer.rl:109
+			case 55:
+//line lexer.rl:113
 				(lexer.p) = (lexer.te) - 1
 				{
 					token_kind = token_IP
 					(lexer.p)++
 					goto _out
 				}
-			case 55:
-//line lexer.rl:111
+			case 56:
+//line lexer.rl:115
 				(lexer.p) = (lexer.te) - 1
 				{
 					token_kind = token_HEX_STRING
 					(lexer.p)++
 					goto _out
 				}
-			case 56:
-//line lexer.rl:118
+			case 57:
+//line lexer.rl:124
 				(lexer.p) = (lexer.te) - 1
 				{
 					lexer.Error(fmt.Sprintf("unexpected character: %q", safeIndex(lexer.data, lexer.ts, lexer.te)))
 					return token_ERROR
 				}
-			case 57:
+			case 58:
 //line NONE:1
 				switch lexer.act {
 				case 1:
@@ -1406,11 +1419,11 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 				case 27:
 					{
 						(lexer.p) = (lexer.te) - 1
-						token_kind = token_FIELD
+						token_kind = token_FUNCTION
 						(lexer.p)++
 						goto _out
 					}
-				case 28:
+				case 29:
 					{
 						(lexer.p) = (lexer.te) - 1
 
@@ -1419,7 +1432,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 					}
 				}
 
-//line lexer.go:1277
+//line lexer.go:1287
 			}
 		}
 
@@ -1434,7 +1447,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 //line NONE:1
 				(lexer.ts) = 0
 
-//line lexer.go:1291
+//line lexer.go:1301
 			}
 		}
 
@@ -1457,7 +1470,7 @@ func (lexer *ruleLexerImpl) Lex(lval *ruleSymType) int {
 		}
 	}
 
-//line lexer.rl:160
+//line lexer.rl:166
 	if lexer.cs != ruleLexerImpl_error {
 		lval.valueLiteral = safeIndex(lexer.data, lexer.ts, lexer.te)
 	}

--- a/lexer.rl
+++ b/lexer.rl
@@ -70,6 +70,10 @@ import (
 	field_char = alpha | digit | '_' | '.';
     field = (alpha | '_') field_char*;  # Must start with alpha or underscore
 	
+	# Function names (similar to fields but can't contain dots)
+	function_char = alpha | digit | '_';
+	function = (alpha | '_') function_char*;  # Must start with alpha or underscore
+	
 	# --- lexer logic ---
 	
 	main := |*
@@ -110,6 +114,8 @@ import (
 		ip_cidr       => { token_kind = token_IP_CIDR;    fbreak; };
 		hex_string    => { token_kind = token_HEX_STRING; fbreak; };
 		regex_pattern => { token_kind = token_REGEX;      fbreak; };
+
+		function => { token_kind = token_FUNCTION; fbreak; };
 
 		# Field names (allow alphanumeric and dots with restrictions)
 		field => { token_kind = token_FIELD; fbreak; };

--- a/parser.gen.go
+++ b/parser.gen.go
@@ -89,7 +89,7 @@ const ruleEofCode = 1
 const ruleErrCode = 2
 const ruleInitialStackSize = 16
 
-//line parser.y:292
+//line parser.y:297
 
 //line yacctab:1
 var ruleExca = [...]int8{
@@ -805,23 +805,28 @@ ruledefault:
 		ruleDollar = ruleS[rulept-4 : rulept+1]
 //line parser.y:272
 		{
-			ruleVAL.rule = newFunctionValue(string(ruleDollar[1].valueLiteral), newArrayValue(ruleDollar[3].arrayValue))
+			fv := newFunctionValue(string(ruleDollar[1].valueLiteral), newArrayValue(ruleDollar[3].arrayValue))
+			if err := fv.ValidateStdlibFnArgs(); err != nil {
+				rulelex.Error(err.Error())
+				return 1
+			}
+			ruleVAL.rule = fv
 		}
 	case 37:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:279
+//line parser.y:284
 		{
 			ruleVAL.arrayValue = []Rule{ruleDollar[1].rule}
 		}
 	case 38:
 		ruleDollar = ruleS[rulept-3 : rulept+1]
-//line parser.y:283
+//line parser.y:288
 		{
 			ruleVAL.arrayValue = append(ruleDollar[1].arrayValue, ruleDollar[3].rule)
 		}
 	case 39:
 		ruleDollar = ruleS[rulept-0 : rulept+1]
-//line parser.y:287
+//line parser.y:292
 		{
 			ruleVAL.arrayValue = ([]Rule)(nil)
 		}

--- a/parser.gen.go
+++ b/parser.gen.go
@@ -805,7 +805,7 @@ ruledefault:
 		ruleDollar = ruleS[rulept-4 : rulept+1]
 //line parser.y:271
 		{
-			fv := newFunctionValue(string(ruleDollar[1].valueLiteral), newArrayValue(ruleDollar[3].arrayValue))
+			fv := newFunctionValue(string(ruleDollar[1].valueLiteral), ruleDollar[3].arrayValue)
 			if err := fv.ValidateStdlibFnArgs(); err != nil {
 				// if this is a stdlib function, validate arguments early at parse time
 				// rather than eval

--- a/parser.gen.go
+++ b/parser.gen.go
@@ -89,7 +89,7 @@ const ruleEofCode = 1
 const ruleErrCode = 2
 const ruleInitialStackSize = 16
 
-//line parser.y:297
+//line parser.y:298
 
 //line yacctab:1
 var ruleExca = [...]int8{
@@ -516,42 +516,42 @@ ruledefault:
 
 	case 1:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:54
+//line parser.y:53
 		{
 			ruleVAL.rule = ruleDollar[1].rule
 			rulelex.Result(ruleVAL.rule)
 		}
 	case 2:
 		ruleDollar = ruleS[rulept-3 : rulept+1]
-//line parser.y:59
+//line parser.y:58
 		{
 			ruleVAL.rule = &nodeAnd{left: ruleDollar[1].rule, right: ruleDollar[3].rule}
 			rulelex.Result(ruleVAL.rule)
 		}
 	case 3:
 		ruleDollar = ruleS[rulept-3 : rulept+1]
-//line parser.y:64
+//line parser.y:63
 		{
 			ruleVAL.rule = &nodeOr{left: ruleDollar[1].rule, right: ruleDollar[3].rule}
 			rulelex.Result(ruleVAL.rule)
 		}
 	case 4:
 		ruleDollar = ruleS[rulept-2 : rulept+1]
-//line parser.y:69
+//line parser.y:68
 		{
 			ruleVAL.rule = &nodeNot{right: ruleDollar[2].rule}
 			rulelex.Result(ruleVAL.rule)
 		}
 	case 5:
 		ruleDollar = ruleS[rulept-3 : rulept+1]
-//line parser.y:74
+//line parser.y:73
 		{
 			ruleVAL.rule = ruleDollar[2].rule
 			rulelex.Result(ruleVAL.rule)
 		}
 	case 6:
 		ruleDollar = ruleS[rulept-3 : rulept+1]
-//line parser.y:83
+//line parser.y:82
 		{
 			ruleVAL.rule = &nodeCompare{
 				lv: ruleDollar[1].rule,
@@ -561,7 +561,7 @@ ruledefault:
 		}
 	case 7:
 		ruleDollar = ruleS[rulept-3 : rulept+1]
-//line parser.y:92
+//line parser.y:91
 		{
 			ruleVAL.rule = &nodeCompare{
 				lv: ruleDollar[1].rule,
@@ -571,7 +571,7 @@ ruledefault:
 		}
 	case 8:
 		ruleDollar = ruleS[rulept-3 : rulept+1]
-//line parser.y:101
+//line parser.y:100
 		{
 			elem, err := parseValueToken(token_REGEX, ruleDollar[3].valueLiteral)
 			if err != nil {
@@ -586,13 +586,13 @@ ruledefault:
 		}
 	case 9:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:114
+//line parser.y:113
 		{
 			ruleVAL.rule = ruleDollar[1].rule
 		}
 	case 10:
 		ruleDollar = ruleS[rulept-3 : rulept+1]
-//line parser.y:119
+//line parser.y:118
 		{
 			ruleVAL.rule = &nodeIn{
 				lv: ruleDollar[1].rule,
@@ -601,7 +601,7 @@ ruledefault:
 		}
 	case 11:
 		ruleDollar = ruleS[rulept-3 : rulept+1]
-//line parser.y:127
+//line parser.y:126
 		{
 			v, err := parseValueToken(token_IP_CIDR, ruleDollar[3].valueLiteral)
 			if err != nil {
@@ -617,91 +617,91 @@ ruledefault:
 		}
 	case 12:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:143
+//line parser.y:142
 		{
 			ruleVAL.operator = op_GT
 		}
 	case 13:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:144
+//line parser.y:143
 		{
 			ruleVAL.operator = op_GE
 		}
 	case 14:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:145
+//line parser.y:144
 		{
 			ruleVAL.operator = op_LT
 		}
 	case 15:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:146
+//line parser.y:145
 		{
 			ruleVAL.operator = op_LE
 		}
 	case 16:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:150
+//line parser.y:149
 		{
 			ruleVAL.operator = op_EQ
 		}
 	case 17:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:151
+//line parser.y:150
 		{
 			ruleVAL.operator = op_NE
 		}
 	case 18:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:152
+//line parser.y:151
 		{
 			ruleVAL.operator = op_CONTAINS
 		}
 	case 19:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:158
+//line parser.y:157
 		{
 			ruleVAL.arrayValue = []Rule{ruleDollar[1].rule}
 		}
 	case 20:
 		ruleDollar = ruleS[rulept-3 : rulept+1]
-//line parser.y:162
+//line parser.y:161
 		{
 			ruleVAL.arrayValue = append(ruleDollar[1].arrayValue, ruleDollar[3].rule)
 		}
 	case 21:
 		ruleDollar = ruleS[rulept-3 : rulept+1]
-//line parser.y:169
+//line parser.y:168
 		{
 			ruleVAL.rule = newArrayValue(ruleDollar[2].arrayValue)
 		}
 	case 22:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:175
+//line parser.y:174
 		{
 			ruleVAL.rule = ruleDollar[1].rule
 		}
 	case 23:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:176
+//line parser.y:175
 		{
 			ruleVAL.rule = ruleDollar[1].rule
 		}
 	case 24:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:177
+//line parser.y:176
 		{
 			ruleVAL.rule = ruleDollar[1].rule
 		}
 	case 25:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:182
+//line parser.y:181
 		{
 			ruleVAL.rule = ruleDollar[1].rule
 		}
 	case 26:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:184
+//line parser.y:183
 		{
 			v, err := parseValueToken(token_STRING, ruleDollar[1].valueLiteral)
 			if err != nil {
@@ -712,7 +712,7 @@ ruledefault:
 		}
 	case 27:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:193
+//line parser.y:192
 		{
 			v, err := parseValueToken(token_BOOL, ruleDollar[1].valueLiteral)
 			if err != nil {
@@ -723,7 +723,7 @@ ruledefault:
 		}
 	case 28:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:202
+//line parser.y:201
 		{
 			v, err := parseValueToken(token_IP, ruleDollar[1].valueLiteral)
 			if err != nil {
@@ -734,7 +734,7 @@ ruledefault:
 		}
 	case 29:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:211
+//line parser.y:210
 		{
 			v, err := parseValueToken(token_IP_CIDR, ruleDollar[1].valueLiteral)
 			if err != nil {
@@ -745,7 +745,7 @@ ruledefault:
 		}
 	case 30:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:220
+//line parser.y:219
 		{
 			v, err := parseValueToken(token_HEX_STRING, ruleDollar[1].valueLiteral)
 			if err != nil {
@@ -756,7 +756,7 @@ ruledefault:
 		}
 	case 31:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:229
+//line parser.y:228
 		{
 			v, err := parseValueToken(token_REGEX, ruleDollar[1].valueLiteral)
 			if err != nil {
@@ -767,7 +767,7 @@ ruledefault:
 		}
 	case 32:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:241
+//line parser.y:240
 		{
 			v, err := parseValueToken(token_INT, ruleDollar[1].valueLiteral)
 			if err != nil {
@@ -778,7 +778,7 @@ ruledefault:
 		}
 	case 33:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:250
+//line parser.y:249
 		{
 			v, err := parseValueToken(token_FLOAT, ruleDollar[1].valueLiteral)
 			if err != nil {
@@ -789,13 +789,13 @@ ruledefault:
 		}
 	case 34:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:259
+//line parser.y:258
 		{
 			ruleVAL.rule = FieldValue(string(ruleDollar[1].valueLiteral))
 		}
 	case 35:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:263
+//line parser.y:262
 		{
 			// there is no syntatic difference between a function call and a field name
 			// so an isolated function name is treated as a field name
@@ -803,10 +803,12 @@ ruledefault:
 		}
 	case 36:
 		ruleDollar = ruleS[rulept-4 : rulept+1]
-//line parser.y:272
+//line parser.y:271
 		{
 			fv := newFunctionValue(string(ruleDollar[1].valueLiteral), newArrayValue(ruleDollar[3].arrayValue))
 			if err := fv.ValidateStdlibFnArgs(); err != nil {
+				// if this is a stdlib function, validate arguments early at parse time
+				// rather than eval
 				rulelex.Error(err.Error())
 				return 1
 			}
@@ -814,19 +816,19 @@ ruledefault:
 		}
 	case 37:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:284
+//line parser.y:285
 		{
 			ruleVAL.arrayValue = []Rule{ruleDollar[1].rule}
 		}
 	case 38:
 		ruleDollar = ruleS[rulept-3 : rulept+1]
-//line parser.y:288
+//line parser.y:289
 		{
 			ruleVAL.arrayValue = append(ruleDollar[1].arrayValue, ruleDollar[3].rule)
 		}
 	case 39:
 		ruleDollar = ruleS[rulept-0 : rulept+1]
-//line parser.y:292
+//line parser.y:293
 		{
 			ruleVAL.arrayValue = ([]Rule)(nil)
 		}

--- a/parser.gen.go
+++ b/parser.gen.go
@@ -15,42 +15,45 @@ type ruleSymType struct {
 	operator     int
 	valueLiteral []byte
 	arrayValue   []Rule
+	functionCall functionCall
 }
 
 const token_FIELD = 57346
-const token_STRING = 57347
-const token_HEX_STRING = 57348
-const token_INT = 57349
-const token_FLOAT = 57350
-const token_BOOL = 57351
-const token_IP_CIDR = 57352
-const token_IP = 57353
-const token_REGEX = 57354
-const op_NOT = 57355
-const op_AND = 57356
-const op_OR = 57357
-const token_LPAREN = 57358
-const token_RPAREN = 57359
-const token_LBRACKET = 57360
-const token_RBRACKET = 57361
-const token_COMMA = 57362
-const op_EQ = 57363
-const op_NE = 57364
-const op_GT = 57365
-const op_GE = 57366
-const op_LT = 57367
-const op_LE = 57368
-const op_CONTAINS = 57369
-const op_MATCHES = 57370
-const op_IN = 57371
-const token_ARRAY = 57372
-const token_ERROR = 57373
+const token_FUNCTION = 57347
+const token_STRING = 57348
+const token_HEX_STRING = 57349
+const token_INT = 57350
+const token_FLOAT = 57351
+const token_BOOL = 57352
+const token_IP_CIDR = 57353
+const token_IP = 57354
+const token_REGEX = 57355
+const op_NOT = 57356
+const op_AND = 57357
+const op_OR = 57358
+const token_LPAREN = 57359
+const token_RPAREN = 57360
+const token_LBRACKET = 57361
+const token_RBRACKET = 57362
+const token_COMMA = 57363
+const op_EQ = 57364
+const op_NE = 57365
+const op_GT = 57366
+const op_GE = 57367
+const op_LT = 57368
+const op_LE = 57369
+const op_CONTAINS = 57370
+const op_MATCHES = 57371
+const op_IN = 57372
+const token_ARRAY = 57373
+const token_ERROR = 57374
 
 var ruleToknames = [...]string{
 	"$end",
 	"error",
 	"$unk",
 	"token_FIELD",
+	"token_FUNCTION",
 	"token_STRING",
 	"token_HEX_STRING",
 	"token_INT",
@@ -86,7 +89,7 @@ const ruleEofCode = 1
 const ruleErrCode = 2
 const ruleInitialStackSize = 16
 
-//line parser.y:258
+//line parser.y:292
 
 //line yacctab:1
 var ruleExca = [...]int8{
@@ -97,60 +100,65 @@ var ruleExca = [...]int8{
 
 const rulePrivate = 57344
 
-const ruleLast = 84
+const ruleLast = 99
 
 var ruleAct = [...]int8{
-	5, 10, 31, 32, 11, 6, 46, 45, 33, 29,
-	30, 24, 25, 26, 27, 44, 19, 20, 20, 36,
-	35, 42, 34, 18, 40, 19, 20, 9, 39, 36,
-	7, 8, 28, 23, 41, 43, 9, 12, 16, 7,
-	8, 13, 15, 14, 17, 3, 36, 47, 4, 2,
-	18, 9, 12, 16, 7, 8, 13, 15, 14, 17,
-	0, 0, 1, 0, 0, 18, 21, 22, 9, 12,
-	16, 7, 8, 13, 15, 14, 17, 0, 0, 0,
-	0, 0, 37, 38,
+	5, 6, 12, 33, 34, 53, 13, 36, 54, 35,
+	31, 32, 26, 27, 28, 29, 52, 51, 22, 48,
+	1, 39, 46, 38, 23, 24, 44, 20, 21, 22,
+	49, 39, 45, 21, 22, 37, 43, 39, 50, 47,
+	9, 40, 41, 42, 7, 8, 30, 25, 11, 2,
+	0, 0, 39, 0, 55, 39, 56, 9, 10, 14,
+	18, 7, 8, 15, 17, 16, 19, 3, 0, 0,
+	4, 0, 20, 9, 10, 14, 18, 7, 8, 15,
+	17, 16, 19, 0, 0, 0, 0, 0, 20, 9,
+	40, 14, 18, 7, 8, 15, 17, 16, 19,
 }
 
 var rulePact = [...]int16{
-	32, 2, -1000, 32, 32, -12, -19, -1000, -1000, -1000,
-	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, 64, 32,
-	32, -1000, 11, 23, -1000, -1000, -1000, -1000, 47, 9,
-	5, -1000, -1000, -1000, -13, -1000, -1000, 3, -1000, -1000,
-	-1000, -1000, -1000, -1000, -1000, 64, -1000, -1000,
+	53, 13, -1000, 53, 53, -12, -19, -1000, -1000, -1000,
+	-10, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
+	85, 53, 53, -1000, 18, 36, -1000, -1000, -1000, -1000,
+	69, 9, 8, -1000, -1000, -1000, 69, -4, -1000, -1000,
+	-1000, 2, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -13,
+	-1000, 85, -1000, -1000, 69, -1000, -1000,
 }
 
 var rulePgo = [...]int8{
-	0, 62, 49, 33, 32, 22, 1, 0, 4, 5,
+	0, 20, 49, 48, 47, 46, 35, 2, 0, 6,
+	1, 30,
 }
 
 var ruleR1 = [...]int8{
 	0, 1, 1, 1, 1, 1, 2, 2, 2, 2,
-	2, 2, 3, 3, 3, 3, 4, 4, 4, 5,
-	5, 8, 9, 9, 6, 6, 6, 6, 6, 6,
-	6, 7, 7, 7,
+	2, 2, 4, 4, 4, 4, 5, 5, 5, 6,
+	6, 9, 10, 10, 10, 7, 7, 7, 7, 7,
+	7, 7, 8, 8, 8, 8, 3, 11, 11, 11,
 }
 
 var ruleR2 = [...]int8{
 	0, 1, 3, 3, 2, 3, 3, 3, 3, 1,
 	3, 3, 1, 1, 1, 1, 1, 1, 1, 1,
 	3, 3, 1, 1, 1, 1, 1, 1, 1, 1,
-	1, 1, 1, 1,
+	1, 1, 1, 1, 1, 1, 4, 1, 3, 0,
 }
 
 var ruleChk = [...]int16{
-	-1000, -1, -2, 13, 16, -7, -9, 7, 8, 4,
-	-6, -8, 5, 9, 11, 10, 6, 12, 18, 14,
-	15, -1, -1, -3, 23, 24, 25, 26, -4, 28,
-	29, 21, 22, 27, -5, -6, -7, -1, -1, 17,
-	-7, -9, 12, -8, 10, 20, 19, -6,
+	-1000, -1, -2, 14, 17, -8, -10, 8, 9, 4,
+	5, -3, -7, -9, 6, 10, 12, 11, 7, 13,
+	19, 15, 16, -1, -1, -4, 24, 25, 26, 27,
+	-5, 29, 30, 22, 23, 28, 17, -6, -7, -8,
+	5, -1, -1, 18, -8, -10, 13, -9, 11, -11,
+	-10, 21, 20, 18, 21, -7, -10,
 }
 
 var ruleDef = [...]int8{
-	0, -2, 1, 0, 0, 24, 9, 31, 32, 33,
-	22, 23, 25, 26, 27, 28, 29, 30, 0, 0,
-	0, 4, 0, 0, 12, 13, 14, 15, 0, 0,
-	0, 16, 17, 18, 0, 19, 24, 2, 3, 5,
-	6, 7, 8, 10, 11, 0, 21, 20,
+	0, -2, 1, 0, 0, 25, 9, 32, 33, 34,
+	35, 22, 23, 24, 26, 27, 28, 29, 30, 31,
+	0, 0, 0, 4, 0, 0, 12, 13, 14, 15,
+	0, 0, 0, 16, 17, 18, 39, 0, 19, 25,
+	35, 2, 3, 5, 6, 7, 8, 10, 11, 0,
+	37, 0, 21, 36, 0, 20, 38,
 }
 
 var ruleTok1 = [...]int8{
@@ -161,6 +169,7 @@ var ruleTok2 = [...]int8{
 	2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
 	12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
 	22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+	32,
 }
 
 var ruleTok3 = [...]int8{
@@ -507,42 +516,42 @@ ruledefault:
 
 	case 1:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:49
+//line parser.y:54
 		{
 			ruleVAL.rule = ruleDollar[1].rule
 			rulelex.Result(ruleVAL.rule)
 		}
 	case 2:
 		ruleDollar = ruleS[rulept-3 : rulept+1]
-//line parser.y:54
+//line parser.y:59
 		{
 			ruleVAL.rule = &nodeAnd{left: ruleDollar[1].rule, right: ruleDollar[3].rule}
 			rulelex.Result(ruleVAL.rule)
 		}
 	case 3:
 		ruleDollar = ruleS[rulept-3 : rulept+1]
-//line parser.y:59
+//line parser.y:64
 		{
 			ruleVAL.rule = &nodeOr{left: ruleDollar[1].rule, right: ruleDollar[3].rule}
 			rulelex.Result(ruleVAL.rule)
 		}
 	case 4:
 		ruleDollar = ruleS[rulept-2 : rulept+1]
-//line parser.y:64
+//line parser.y:69
 		{
 			ruleVAL.rule = &nodeNot{right: ruleDollar[2].rule}
 			rulelex.Result(ruleVAL.rule)
 		}
 	case 5:
 		ruleDollar = ruleS[rulept-3 : rulept+1]
-//line parser.y:69
+//line parser.y:74
 		{
 			ruleVAL.rule = ruleDollar[2].rule
 			rulelex.Result(ruleVAL.rule)
 		}
 	case 6:
 		ruleDollar = ruleS[rulept-3 : rulept+1]
-//line parser.y:78
+//line parser.y:83
 		{
 			ruleVAL.rule = &nodeCompare{
 				lv: ruleDollar[1].rule,
@@ -552,7 +561,7 @@ ruledefault:
 		}
 	case 7:
 		ruleDollar = ruleS[rulept-3 : rulept+1]
-//line parser.y:87
+//line parser.y:92
 		{
 			ruleVAL.rule = &nodeCompare{
 				lv: ruleDollar[1].rule,
@@ -562,7 +571,7 @@ ruledefault:
 		}
 	case 8:
 		ruleDollar = ruleS[rulept-3 : rulept+1]
-//line parser.y:96
+//line parser.y:101
 		{
 			elem, err := parseValueToken(token_REGEX, ruleDollar[3].valueLiteral)
 			if err != nil {
@@ -577,13 +586,13 @@ ruledefault:
 		}
 	case 9:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:109
+//line parser.y:114
 		{
 			ruleVAL.rule = ruleDollar[1].rule
 		}
 	case 10:
 		ruleDollar = ruleS[rulept-3 : rulept+1]
-//line parser.y:114
+//line parser.y:119
 		{
 			ruleVAL.rule = &nodeIn{
 				lv: ruleDollar[1].rule,
@@ -592,7 +601,7 @@ ruledefault:
 		}
 	case 11:
 		ruleDollar = ruleS[rulept-3 : rulept+1]
-//line parser.y:122
+//line parser.y:127
 		{
 			v, err := parseValueToken(token_IP_CIDR, ruleDollar[3].valueLiteral)
 			if err != nil {
@@ -608,85 +617,91 @@ ruledefault:
 		}
 	case 12:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:138
+//line parser.y:143
 		{
 			ruleVAL.operator = op_GT
 		}
 	case 13:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:139
+//line parser.y:144
 		{
 			ruleVAL.operator = op_GE
 		}
 	case 14:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:140
+//line parser.y:145
 		{
 			ruleVAL.operator = op_LT
 		}
 	case 15:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:141
+//line parser.y:146
 		{
 			ruleVAL.operator = op_LE
 		}
 	case 16:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:145
+//line parser.y:150
 		{
 			ruleVAL.operator = op_EQ
 		}
 	case 17:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:146
+//line parser.y:151
 		{
 			ruleVAL.operator = op_NE
 		}
 	case 18:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:147
+//line parser.y:152
 		{
 			ruleVAL.operator = op_CONTAINS
 		}
 	case 19:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:153
+//line parser.y:158
 		{
 			ruleVAL.arrayValue = []Rule{ruleDollar[1].rule}
 		}
 	case 20:
 		ruleDollar = ruleS[rulept-3 : rulept+1]
-//line parser.y:157
+//line parser.y:162
 		{
 			ruleVAL.arrayValue = append(ruleDollar[1].arrayValue, ruleDollar[3].rule)
 		}
 	case 21:
 		ruleDollar = ruleS[rulept-3 : rulept+1]
-//line parser.y:164
+//line parser.y:169
 		{
 			ruleVAL.rule = newArrayValue(ruleDollar[2].arrayValue)
 		}
 	case 22:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:170
+//line parser.y:175
 		{
 			ruleVAL.rule = ruleDollar[1].rule
 		}
 	case 23:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:171
+//line parser.y:176
 		{
 			ruleVAL.rule = ruleDollar[1].rule
 		}
 	case 24:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:176
+//line parser.y:177
 		{
 			ruleVAL.rule = ruleDollar[1].rule
 		}
 	case 25:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:178
+//line parser.y:182
+		{
+			ruleVAL.rule = ruleDollar[1].rule
+		}
+	case 26:
+		ruleDollar = ruleS[rulept-1 : rulept+1]
+//line parser.y:184
 		{
 			v, err := parseValueToken(token_STRING, ruleDollar[1].valueLiteral)
 			if err != nil {
@@ -695,9 +710,9 @@ ruledefault:
 			}
 			ruleVAL.rule = v
 		}
-	case 26:
+	case 27:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:187
+//line parser.y:193
 		{
 			v, err := parseValueToken(token_BOOL, ruleDollar[1].valueLiteral)
 			if err != nil {
@@ -706,9 +721,9 @@ ruledefault:
 			}
 			ruleVAL.rule = v
 		}
-	case 27:
+	case 28:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:196
+//line parser.y:202
 		{
 			v, err := parseValueToken(token_IP, ruleDollar[1].valueLiteral)
 			if err != nil {
@@ -717,9 +732,9 @@ ruledefault:
 			}
 			ruleVAL.rule = v
 		}
-	case 28:
+	case 29:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:205
+//line parser.y:211
 		{
 			v, err := parseValueToken(token_IP_CIDR, ruleDollar[1].valueLiteral)
 			if err != nil {
@@ -728,9 +743,9 @@ ruledefault:
 			}
 			ruleVAL.rule = v
 		}
-	case 29:
+	case 30:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:214
+//line parser.y:220
 		{
 			v, err := parseValueToken(token_HEX_STRING, ruleDollar[1].valueLiteral)
 			if err != nil {
@@ -739,9 +754,9 @@ ruledefault:
 			}
 			ruleVAL.rule = v
 		}
-	case 30:
+	case 31:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:223
+//line parser.y:229
 		{
 			v, err := parseValueToken(token_REGEX, ruleDollar[1].valueLiteral)
 			if err != nil {
@@ -750,9 +765,9 @@ ruledefault:
 			}
 			ruleVAL.rule = v
 		}
-	case 31:
+	case 32:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:235
+//line parser.y:241
 		{
 			v, err := parseValueToken(token_INT, ruleDollar[1].valueLiteral)
 			if err != nil {
@@ -761,9 +776,9 @@ ruledefault:
 			}
 			ruleVAL.rule = v
 		}
-	case 32:
+	case 33:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:244
+//line parser.y:250
 		{
 			v, err := parseValueToken(token_FLOAT, ruleDollar[1].valueLiteral)
 			if err != nil {
@@ -772,11 +787,43 @@ ruledefault:
 			}
 			ruleVAL.rule = v
 		}
-	case 33:
+	case 34:
 		ruleDollar = ruleS[rulept-1 : rulept+1]
-//line parser.y:253
+//line parser.y:259
 		{
 			ruleVAL.rule = FieldValue(string(ruleDollar[1].valueLiteral))
+		}
+	case 35:
+		ruleDollar = ruleS[rulept-1 : rulept+1]
+//line parser.y:263
+		{
+			// there is no syntatic difference between a function call and a field name
+			// so an isolated function name is treated as a field name
+			ruleVAL.rule = FieldValue(string(ruleDollar[1].valueLiteral))
+		}
+	case 36:
+		ruleDollar = ruleS[rulept-4 : rulept+1]
+//line parser.y:272
+		{
+			ruleVAL.rule = newFunctionValue(string(ruleDollar[1].valueLiteral), newArrayValue(ruleDollar[3].arrayValue))
+		}
+	case 37:
+		ruleDollar = ruleS[rulept-1 : rulept+1]
+//line parser.y:279
+		{
+			ruleVAL.arrayValue = []Rule{ruleDollar[1].rule}
+		}
+	case 38:
+		ruleDollar = ruleS[rulept-3 : rulept+1]
+//line parser.y:283
+		{
+			ruleVAL.arrayValue = append(ruleDollar[1].arrayValue, ruleDollar[3].rule)
+		}
+	case 39:
+		ruleDollar = ruleS[rulept-0 : rulept+1]
+//line parser.y:287
+		{
+			ruleVAL.arrayValue = ([]Rule)(nil)
 		}
 	}
 	goto rulestack /* stack new state and value */

--- a/parser.go
+++ b/parser.go
@@ -174,6 +174,8 @@ func valueTokenString(typ int) string {
 		return "regex"
 	case token_FIELD:
 		return "field identifier"
+	case token_FUNCTION:
+		return "function"
 	case token_LPAREN:
 		return `"("`
 	case token_RPAREN:
@@ -197,4 +199,9 @@ type ValueParseError struct {
 
 func (e ValueParseError) Error() string {
 	return fmt.Sprintf("parsing %s value %q: %v", valueTokenString(e.TokenType), e.Value, e.Err)
+}
+
+type functionCall struct {
+	fn   string
+	args []Rule
 }

--- a/parser.y
+++ b/parser.y
@@ -270,7 +270,14 @@ numeric_value_token:
 function_call:
 	token_FUNCTION token_LPAREN function_arguments token_RPAREN
 	{
-		$$ = newFunctionValue(string($1), newArrayValue($3))
+		fv := newFunctionValue(string($1), newArrayValue($3))
+		if err := fv.ValidateStdlibFnArgs(); err != nil {
+			// if this is a stdlib function, validate arguments early at parse time
+			// rather than eval
+			rulelex.Error(err.Error())
+			return 1
+		}
+		$$ = fv
 	}
 	;
 

--- a/parser.y
+++ b/parser.y
@@ -7,10 +7,13 @@ package rulekit
 	operator      int
 	valueLiteral  []byte
 	arrayValue    []Rule
+	functionCall  functionCall
 }
 
 // Type declarations for non-terminals (rules)
 %type <rule> search_condition predicate
+// %type <nodeFunction> function_call
+%type <rule> function_call
 %type <operator> ineq_operator eq_operator
 %type <arrayValue> array_values
 // value tokens
@@ -18,8 +21,10 @@ package rulekit
 %type <rule> numeric_value_token // int or float values
 %type <rule> array_value_token // array values
 %type <rule> array_or_single_value_token // arrays or single values
+%type <arrayValue> function_arguments // function arguments
 
 %token <valueLiteral> token_FIELD
+%token <valueLiteral> token_FUNCTION
 %token <valueLiteral> token_STRING token_HEX_STRING
 %token <valueLiteral> token_INT token_FLOAT
 %token <valueLiteral> token_BOOL
@@ -167,8 +172,9 @@ array_value_token:
 	;
 
 array_or_single_value_token:
-	value_token         { $$ = $1 }
-	| array_value_token { $$ = $1 }
+	function_call         { $$ = $1 }
+	| value_token         { $$ = $1 }
+	| array_value_token   { $$ = $1 }
 	;
 
 // value tokens
@@ -252,6 +258,34 @@ numeric_value_token:
 	| token_FIELD
 	{
 		$$ = FieldValue(string($1))
+	}
+	| token_FUNCTION
+	{
+		// there is no syntatic difference between a function call and a field name
+		// so an isolated function name is treated as a field name
+		$$ = FieldValue(string($1))
+	}
+	;
+
+function_call:
+	token_FUNCTION token_LPAREN function_arguments token_RPAREN
+	{
+		$$ = newFunctionValue(string($1), newArrayValue($3))
+	}
+	;
+
+function_arguments:
+	array_or_single_value_token
+	{
+		$$ = []Rule{$1}
+	}
+	| function_arguments token_COMMA array_or_single_value_token
+	{
+		$$ = append($1, $3)
+	}
+	| /* nothing */
+	{
+		$$ = ([]Rule)(nil)
 	}
 	;
 

--- a/parser.y
+++ b/parser.y
@@ -12,7 +12,6 @@ package rulekit
 
 // Type declarations for non-terminals (rules)
 %type <rule> search_condition predicate
-// %type <nodeFunction> function_call
 %type <rule> function_call
 %type <operator> ineq_operator eq_operator
 %type <arrayValue> array_values

--- a/parser.y
+++ b/parser.y
@@ -269,7 +269,7 @@ numeric_value_token:
 function_call:
 	token_FUNCTION token_LPAREN function_arguments token_RPAREN
 	{
-		fv := newFunctionValue(string($1), newArrayValue($3))
+		fv := newFunctionValue(string($1), $3)
 		if err := fv.ValidateStdlibFnArgs(); err != nil {
 			// if this is a stdlib function, validate arguments early at parse time
 			// rather than eval

--- a/rule.go
+++ b/rule.go
@@ -143,6 +143,16 @@ type Rule interface {
 	String() string
 }
 
+type RuleFunc func(*Ctx) Result
+
+func (f RuleFunc) Eval(ctx *Ctx) Result {
+	return f(ctx)
+}
+
+func (f RuleFunc) String() string {
+	return "<fn>"
+}
+
 type rule struct {
 	Rule
 }

--- a/rule.go
+++ b/rule.go
@@ -160,7 +160,11 @@ func (r *rule) String() string {
 	if r.Rule == nil {
 		return "<empty>"
 	}
-	return strings.TrimSuffix(strings.TrimPrefix(r.Rule.String(), "("), ")")
+	s := r.Rule.String()
+	if len(s) > 0 && s[0] == '(' {
+		return strings.TrimSuffix(s[1:], ")")
+	}
+	return s
 }
 
 type Result struct {
@@ -234,7 +238,11 @@ func (e *ParseError) Error() string {
 			"token_STRING", `"string"`,
 			"token_HEX_STRING", `"hex"`,
 			"token_ARRAY", `"array"`,
-			"token_LBRACKET", `"array"`,
+			"token_LBRACKET", `"["`,
+			"token_RBRACKET", `"]"`,
+			"token_LPAREN", `"("`,
+			"token_RPAREN", `")"`,
+			"token_FUNCTION", `"function or field identifier"`,
 		)
 		result += "\n" + replacer.Replace(e.Message)
 	}

--- a/rule_test.go
+++ b/rule_test.go
@@ -920,6 +920,24 @@ func TestStringAutomaticCasting(t *testing.T) {
 	}
 }
 
+func TestFunctionParsing(t *testing.T) {
+	parsed := MustParse(`func_name(
+		fieldarg,
+		192.168.0.0,
+		[1, 2, 3],
+		nested_func(true)
+	)`)
+
+	fn := parsed.(*rule).Rule.(*FunctionValue)
+	require.Equal(t, "func_name", fn.fn)
+	require.Len(t, fn.args.vals, 4)
+	assert.IsType(t, FieldValue(""), fn.args.vals[0])
+	assert.IsType(t, &LiteralValue[any]{}, fn.args.vals[1])
+	assert.IsType(t, net.IP{}, fn.args.vals[1].(*LiteralValue[any]).value)
+	assert.IsType(t, &ArrayValue{}, fn.args.vals[2])
+	assert.IsType(t, &FunctionValue{}, fn.args.vals[3])
+}
+
 type ruleAssertion struct {
 	t      *testing.T
 	rule   Rule

--- a/rule_test.go
+++ b/rule_test.go
@@ -735,6 +735,11 @@ func assertParseError(t *testing.T, rule string) {
 	assert.Error(t, err)
 }
 
+func assertParseErrorValue(t *testing.T, rule string, expected string) {
+	_, err := Parse(rule)
+	assert.EqualError(t, err, expected)
+}
+
 func toJSON(t *testing.T, v any) string {
 	t.Helper()
 	b, err := json.Marshal(v)


### PR DESCRIPTION
- syntax: `function_name(argument1, argument2)`
- functions can accept zero or more arguments
- arguments can be of any type including arrays and nested function calls
- add a "functions standard library" initially with just a `starts_with` function.
