### PR TITLE
add index function to stdlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ domain matches /example\.com$/
 ```
 
 When evaluated against:
+
 - `map[string]any{"domain": "example.com"}` → returns **true**
 - `map[string]any{"domain": "qpoint.io"}` → returns **false**
 
@@ -44,13 +45,13 @@ import "github.com/qpoint-io/rulekit"
 
 r, err := rule.Parse(`domain matches /example\.com$/ and port == 8080`)
 if err != nil { /* ... */ }
-    
+
 // define input data
 input := rulekit.KV{
     "domain": "example.com",
     "port": 8080,
 }
-    
+
 // evaluate the rule
 result := r.Eval(&rulekit.Ctx{KV: inputData})
 
@@ -75,49 +76,50 @@ When a rule is evaluated, it returns a `Result` struct containing:
 - `EvaluatedRule`: The sub-rule that determined the returned value. Useful for debugging and understanding which part of a complex rule caused the result.
 
 The Result also provides additional helper methods:
+
 - `Pass()`: Returns true if the rule returns true/a non-zero value with no errors
 - `Fail()`: Returns true if the rule returns false/a zero value with no errors
 - `Ok()`: Returns true if the rule executed with no error
 
 ## Supported Operators
 
-| Operator | Alias | Description |
-|----------|--------------|-------------|
-| `or` | `\|\|` | Logical OR |
-| `and` | `&&` | Logical AND |
-| `not` | `!` | Logical NOT |
-| `()` | | Parentheses for grouping |
-| `==` | `eq` | Equal to |
-| `!=` | `ne` | Not equal to |
-| `>` | `gt` | Greater than |
-| `>=` | `ge` | Greater than or equal to |
-| `<` | `lt` | Less than |
-| `<=` | `le` | Less than or equal to |
-| `contains` | | Check if a value contains another value |
-| `in` | | Check if a value is contained within an array or an IP within a CIDR |
-| `matches` | | Match against a regular expression |
+| Operator   | Alias  | Description                                                          |
+| ---------- | ------ | -------------------------------------------------------------------- |
+| `or`       | `\|\|` | Logical OR                                                           |
+| `and`      | `&&`   | Logical AND                                                          |
+| `not`      | `!`    | Logical NOT                                                          |
+| `()`       |        | Parentheses for grouping                                             |
+| `==`       | `eq`   | Equal to                                                             |
+| `!=`       | `ne`   | Not equal to                                                         |
+| `>`        | `gt`   | Greater than                                                         |
+| `>=`       | `ge`   | Greater than or equal to                                             |
+| `<`        | `lt`   | Less than                                                            |
+| `<=`       | `le`   | Less than or equal to                                                |
+| `contains` |        | Check if a value contains another value                              |
+| `in`       |        | Check if a value is contained within an array or an IP within a CIDR |
+| `matches`  |        | Match against a regular expression                                   |
 
 ## Supported Types
 
 ### Basic values
 
-| Type | Used As | Example | Description |
-|------|---------|---------|-------------|
-| **bool** | VALUE, FIELD | `true` | Valid values: `true`, `false` |
-| **number** | VALUE, FIELD | `8080` | Integer or float. Parsed as either int64 or uint64 if out of range for int64, or float64 if float. |
-| **string** | VALUE, FIELD | `"domain.com"` | A double-quoted string. Quotes may be escaped with a backslash: `"a string \"with\" quotes"`. Any quoted value is parsed as a string. |
-| **IP address** | VALUE, FIELD | `192.168.1.1`, `2001:db8:3333:4444:cccc:dddd:eeee:ffff` | An IPv4, IPv6, or an IPv6 dual address. Maps to Go type: `net.IP` |
-| **CIDR** | VALUE | `192.168.1.0/24`, `2001:db8:3333:4444:cccc:dddd:eeee:ffff/64` | An IPv4 or IPv6 CIDR block. Maps to Go type: `*net.IPNet` |
-| **Hexadecimal string** | VALUE, FIELD | `12:34:56:78:ab` (MAC address), `504f5354` (hex string "POST") | A hexadecimal string, optionally separated by colons. |
-| **Regex** | VALUE | `/example\.com$/` | A Go-style regular expression. Must be surrounded by forward slashes. May not be quoted with double quotes (otherwise it will be parsed as a string). Maps to Go type: `*regexp.Regexp` |
+| Type                   | Used As      | Example                                                        | Description                                                                                                                                                                             |
+| ---------------------- | ------------ | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **bool**               | VALUE, FIELD | `true`                                                         | Valid values: `true`, `false`                                                                                                                                                           |
+| **number**             | VALUE, FIELD | `8080`                                                         | Integer or float. Parsed as either int64 or uint64 if out of range for int64, or float64 if float.                                                                                      |
+| **string**             | VALUE, FIELD | `"domain.com"`                                                 | A double-quoted string. Quotes may be escaped with a backslash: `"a string \"with\" quotes"`. Any quoted value is parsed as a string.                                                   |
+| **IP address**         | VALUE, FIELD | `192.168.1.1`, `2001:db8:3333:4444:cccc:dddd:eeee:ffff`        | An IPv4, IPv6, or an IPv6 dual address. Maps to Go type: `net.IP`                                                                                                                       |
+| **CIDR**               | VALUE        | `192.168.1.0/24`, `2001:db8:3333:4444:cccc:dddd:eeee:ffff/64`  | An IPv4 or IPv6 CIDR block. Maps to Go type: `*net.IPNet`                                                                                                                               |
+| **Hexadecimal string** | VALUE, FIELD | `12:34:56:78:ab` (MAC address), `504f5354` (hex string "POST") | A hexadecimal string, optionally separated by colons.                                                                                                                                   |
+| **Regex**              | VALUE        | `/example\.com$/`                                              | A Go-style regular expression. Must be surrounded by forward slashes. May not be quoted with double quotes (otherwise it will be parsed as a string). Maps to Go type: `*regexp.Regexp` |
 
 ### Constructs
 
-| Type | Used As | Example | Description |
-|------|---------|---------|-------------|
-| **Array** | VALUE | `[1, "string", true]` | An array of mixed value types. Can be used with most operators including `in` and `contains`. |
-| **Function** | VALUE | `starts_with(url, "https://")` | A function call with optional arguments. Can be built-in or custom. |
-| **Macro** | VALUE | `isValidRequest()` | A zero-argument function that encapsulates a predefined rule. |
+| Type         | Used As | Example                        | Description                                                                                   |
+| ------------ | ------- | ------------------------------ | --------------------------------------------------------------------------------------------- |
+| **Array**    | VALUE   | `[1, "string", true]`          | An array of mixed value types. Can be used with most operators including `in` and `contains`. |
+| **Function** | VALUE   | `starts_with(url, "https://")` | A function call with optional arguments. Can be built-in or custom.                           |
+| **Macro**    | VALUE   | `isValidRequest()`             | A zero-argument function that encapsulates a predefined rule.                                 |
 
 ## Macros
 
@@ -152,9 +154,10 @@ Functions can be called inside rules and used as value objects. Functions may ac
 
 Rulekit comes with a built-in standard library of functions:
 
-| Function | Description | Example |
-|----------|-------------|---------|
-| `starts_with(value, prefix)` | Checks if a value starts with the given prefix. Works with strings, numbers, and other types by converting them to strings. | `starts_with(url, "https://")` |
+| Function                     | Description                                                                                                                 | Example                               |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| `starts_with(value, prefix)` | Checks if a value starts with the given prefix. Works with strings, numbers, and other types by converting them to strings. | `starts_with(url, "https://")`        |
+| `index(container, key)`      | Indexes into a map or slice                                                                                                 | `index(["one", "two"], 0)` -> `"one"` |
 
 ### Custom Functions
 

--- a/functions_stdlib.go
+++ b/functions_stdlib.go
@@ -26,4 +26,56 @@ var StdlibFuncs = map[string]*Function{
 			}
 		},
 	},
+
+	// index(container, key)
+	//
+	// index is used to index into a map via a string key or an array via an integer index.
+	//
+	// e.g. index(map, "key")
+	//      map: map[string]any{"key": "value"} -> "value"
+	//
+	//      index(["first", "second"], 1) -> "second"
+	"index": {
+		Args: []FunctionArg{
+			{Name: "container"},
+			{Name: "key"},
+		},
+		Eval: func(args map[string]any) Result {
+			container, err := IndexFuncArg[any](args, "container")
+			if err != nil {
+				return Result{Error: err}
+			}
+
+			switch c := container.(type) {
+			case KV:
+				key, err := IndexFuncArg[string](args, "key")
+				if err != nil {
+					return Result{Error: err}
+				}
+
+				val, ok := IndexKV(c, key)
+				if !ok {
+					return Result{Error: fmt.Errorf("key %q not found", key)}
+				}
+
+				return Result{Value: val}
+
+			case []any:
+				key, err := IndexFuncArg[int64](args, "key")
+				if err != nil {
+					return Result{Error: err}
+				}
+
+				if key < 0 || int(key) >= len(c) {
+					return Result{Error: fmt.Errorf("index %d out of bounds", key)}
+				}
+
+				return Result{
+					Value: c[key],
+				}
+			}
+
+			return Result{Error: fmt.Errorf("container must be a map or array")}
+		},
+	},
 }


### PR DESCRIPTION

`index(container, key)`

index is used to index into a map via a string key or an array via an integer index.

```
e.g. `index(map, "key")`
     map: `map[string]any{"key": "value"}` -> `"value"`

     `index(["first", "second"], 1)` -> `"second"`
```