### PR TITLE
bump go to 1.26.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.1"
 
       - name: Test
         run: go test -v ./...

--- a/example/rulecli/go.mod
+++ b/example/rulecli/go.mod
@@ -1,6 +1,6 @@
 module github.com/qpoint-io/rulekit/example/rulecli
 
-go 1.25.3
+go 1.26.2
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/qpoint-io/rulekit
 
-go 1.26.0
+go 1.26.2
 
 require (
 	github.com/hashicorp/go-multierror v1.1.1


### PR DESCRIPTION
Updates this repo to Go 1.26.2.\n\n- bumps the go directive where applicable\n- updates Go Docker base image/version references used by this repo