### PR TITLE
bump go to 1.26.2

### DIFF
--- a/example/rulecli/go.mod
+++ b/example/rulecli/go.mod
@@ -1,6 +1,6 @@
 module github.com/qpoint-io/rulekit/example/rulecli
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/qpoint-io/rulekit
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/hashicorp/go-multierror v1.1.1


### PR DESCRIPTION
Updates this repo to Go 1.26.2 only.